### PR TITLE
ENH: Add more conjugacy coefficient updates

### DIFF
--- a/CppCore/tests/test_optim_cg.cc
+++ b/CppCore/tests/test_optim_cg.cc
@@ -23,12 +23,17 @@
 #include "xtsci/optimize/trial_functions/quadratic.hpp"
 #include "xtsci/optimize/trial_functions/rosenbrock.hpp"
 
+#include "xtsci/optimize/linesearch/conjugacy/fletcher_reeves.hpp"
+#include "xtsci/optimize/linesearch/conjugacy/polak_ribiere.hpp"
+
 #include <catch2/catch_all.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
   xts::optimize::trial_functions::Rosenbrock<double> rosen;
   xts::optimize::OptimizeControl<double> control;
+  xts::optimize::linesearch::conjugacy::FletcherReeves<double> fletcherreeves;
+  xts::optimize::linesearch::conjugacy::PolakRibiere<double> polakribiere;
   control.tol = 1e-6;
 
   xt::xarray<double> initial_guess = {-1.3, 1.8};
@@ -44,7 +49,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(armijo, geomStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);
@@ -61,7 +66,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(armijo, bisectionStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);
@@ -77,7 +82,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(armijo, goldenStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);
@@ -115,7 +120,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(strongwolfe, geomStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);
@@ -132,7 +137,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(strongwolfe, bisectionStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);
@@ -148,7 +153,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(strongwolfe, goldenStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);
@@ -186,7 +191,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(goldstein, geomStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);
@@ -203,7 +208,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(goldstein, bisectionStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);
@@ -219,7 +224,7 @@ TEST_CASE("ConjugateGradientOptimizer with Backtracking Search") {
       xts::optimize::linesearch::search_strategy::BacktrackingSearch<double>
           backtracking(goldstein, goldenStep);
       xts::optimize::minimize::ConjugateGradientOptimizer<double> optimizer(
-          backtracking);
+          backtracking, fletcherreeves);
 
       xts::optimize::OptimizeResult<double> result =
           optimizer.optimize(rosen, cstate, control);

--- a/CppCore/tiny_cli.cpp
+++ b/CppCore/tiny_cli.cpp
@@ -24,6 +24,7 @@
 
 #include "xtsci/optimize/linesearch/conjugacy/fletcher_reeves.hpp"
 #include "xtsci/optimize/linesearch/conjugacy/hestenes-stiefel.hpp"
+#include "xtsci/optimize/linesearch/conjugacy/hybridized_conj.hpp"
 #include "xtsci/optimize/linesearch/conjugacy/liu_storey.hpp"
 #include "xtsci/optimize/linesearch/conjugacy/polak_ribiere.hpp"
 
@@ -108,8 +109,12 @@ int main(int argc, char *argv[]) {
   xts::optimize::linesearch::conjugacy::PolakRibiere<double> polakribiere;
   xts::optimize::linesearch::conjugacy::HestenesStiefel<double> hestenesstiefel;
   xts::optimize::linesearch::conjugacy::LiuStorey<double> liustorey;
+  xts::optimize::linesearch::conjugacy::HybridizedConj<double> hybrid_min(
+      hestenesstiefel, polakribiere,
+      [](double a, double b) -> double { return std::min(a, b); });
+
   xts::optimize::minimize::ConjugateGradientOptimizer<double> cgopt(
-      moorethuente, hestenesstiefel);
+      moorethuente, hybrid_min);
 
   xts::optimize::minimize::BFGSOptimizer<double> bfgsopt(backtracking);
   xts::optimize::minimize::LBFGSOptimizer<double> lbfgsopt(zoom, 30);

--- a/CppCore/tiny_cli.cpp
+++ b/CppCore/tiny_cli.cpp
@@ -22,6 +22,9 @@
 #include "xtsci/optimize/linesearch/search_strategy/moore_thuente.hpp"
 #include "xtsci/optimize/linesearch/search_strategy/zoom.hpp"
 
+#include "xtsci/optimize/linesearch/conjugacy/fletcher_reeves.hpp"
+#include "xtsci/optimize/linesearch/conjugacy/polak_ribiere.hpp"
+
 #include "xtsci/optimize/linesearch/step_size/bisect.hpp"
 #include "xtsci/optimize/linesearch/step_size/cubic.hpp"
 #include "xtsci/optimize/linesearch/step_size/geom.hpp"
@@ -97,10 +100,13 @@ int main(int argc, char *argv[]) {
   xts::optimize::linesearch::search_strategy::ZoomLineSearch<double> zoom(
       bisectionStep, 1e-4, 0.9);
   xts::optimize::linesearch::search_strategy::MooreThuenteLineSearch<double>
-      moorethuente(goldenStep, 1e-3, 0.3);
+      moorethuente(bisectionStep, 1e-3, 0.3);
 
+  xts::optimize::linesearch::conjugacy::FletcherReeves<double> fletcherreeves;
+  xts::optimize::linesearch::conjugacy::PolakRibiere<double> polakribiere;
   xts::optimize::minimize::ConjugateGradientOptimizer<double> cgopt(
-      backtracking);
+      moorethuente, polakribiere);
+
   xts::optimize::minimize::BFGSOptimizer<double> bfgsopt(backtracking);
   xts::optimize::minimize::LBFGSOptimizer<double> lbfgsopt(zoom, 30);
   xts::optimize::minimize::ADAMOptimizer<double> adaopt(backtracking);
@@ -113,7 +119,7 @@ int main(int argc, char *argv[]) {
   xt::xarray<double> direction = {0.0, 0.0};
   xts::optimize::SearchState<double> cstate = {initial_guess, direction};
   xts::optimize::OptimizeResult<double> result =
-      lbfgsopt.optimize(mullerbrown, cstate, control);
+      cgopt.optimize(rosen, cstate, control);
 
   // xts::optimize::OptimizeResult<double> result =
   //     psopt.optimize(mullerbrown, {-512, -512}, {512, 512});

--- a/CppCore/tiny_cli.cpp
+++ b/CppCore/tiny_cli.cpp
@@ -23,6 +23,8 @@
 #include "xtsci/optimize/linesearch/search_strategy/zoom.hpp"
 
 #include "xtsci/optimize/linesearch/conjugacy/fletcher_reeves.hpp"
+#include "xtsci/optimize/linesearch/conjugacy/hestenes-stiefel.hpp"
+#include "xtsci/optimize/linesearch/conjugacy/liu_storey.hpp"
 #include "xtsci/optimize/linesearch/conjugacy/polak_ribiere.hpp"
 
 #include "xtsci/optimize/linesearch/step_size/bisect.hpp"
@@ -104,8 +106,10 @@ int main(int argc, char *argv[]) {
 
   xts::optimize::linesearch::conjugacy::FletcherReeves<double> fletcherreeves;
   xts::optimize::linesearch::conjugacy::PolakRibiere<double> polakribiere;
+  xts::optimize::linesearch::conjugacy::HestenesStiefel<double> hestenesstiefel;
+  xts::optimize::linesearch::conjugacy::LiuStorey<double> liustorey;
   xts::optimize::minimize::ConjugateGradientOptimizer<double> cgopt(
-      moorethuente, polakribiere);
+      moorethuente, hestenesstiefel);
 
   xts::optimize::minimize::BFGSOptimizer<double> bfgsopt(backtracking);
   xts::optimize::minimize::LBFGSOptimizer<double> lbfgsopt(zoom, 30);
@@ -119,7 +123,7 @@ int main(int argc, char *argv[]) {
   xt::xarray<double> direction = {0.0, 0.0};
   xts::optimize::SearchState<double> cstate = {initial_guess, direction};
   xts::optimize::OptimizeResult<double> result =
-      cgopt.optimize(rosen, cstate, control);
+      cgopt.optimize(mullerbrown, cstate, control);
 
   // xts::optimize::OptimizeResult<double> result =
   //     psopt.optimize(mullerbrown, {-512, -512}, {512, 512});

--- a/CppCore/xtsci/optimize/linesearch/base.hpp
+++ b/CppCore/xtsci/optimize/linesearch/base.hpp
@@ -53,6 +53,15 @@ public:
                               const SearchState<ScalarType> &state) const = 0;
 };
 
+template <typename ScalarType> class ConjugacyCoefficientStrategy {
+public:
+  virtual ~ConjugacyCoefficientStrategy() = default;
+
+  virtual ScalarType
+  computeBeta(const xt::xarray<ScalarType> &current_gradient,
+              const xt::xarray<ScalarType> &previous_gradient) const = 0;
+};
+
 } // namespace linesearch
 } // namespace optimize
 } // namespace xts

--- a/CppCore/xtsci/optimize/linesearch/base.hpp
+++ b/CppCore/xtsci/optimize/linesearch/base.hpp
@@ -53,13 +53,17 @@ public:
                               const SearchState<ScalarType> &state) const = 0;
 };
 
+template <typename ScalarType> struct ConjugacyContext {
+  xt::xarray<ScalarType> current_gradient;
+  xt::xarray<ScalarType> previous_gradient;
+};
+
 template <typename ScalarType> class ConjugacyCoefficientStrategy {
 public:
   virtual ~ConjugacyCoefficientStrategy() = default;
 
   virtual ScalarType
-  computeBeta(const xt::xarray<ScalarType> &current_gradient,
-              const xt::xarray<ScalarType> &previous_gradient) const = 0;
+  computeBeta(const ConjugacyContext<ScalarType> &context) const = 0;
 };
 
 } // namespace linesearch

--- a/CppCore/xtsci/optimize/linesearch/conjugacy/fletcher_reeves.hpp
+++ b/CppCore/xtsci/optimize/linesearch/conjugacy/fletcher_reeves.hpp
@@ -1,0 +1,31 @@
+#pragma once
+// MIT License
+// Copyright 2023--present Rohit Goswami <HaoZeke>
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "xtensor-blas/xlinalg.hpp"
+
+#include "xtsci/optimize/linesearch/base.hpp"
+
+namespace xts {
+namespace optimize {
+namespace linesearch {
+namespace conjugacy {
+template <typename ScalarType>
+class FletcherReeves : public ConjugacyCoefficientStrategy<ScalarType> {
+public:
+  ScalarType
+  computeBeta(const xt::xarray<ScalarType> &current_gradient,
+              const xt::xarray<ScalarType> &previous_gradient) const override {
+    return xt::linalg::dot(current_gradient, current_gradient)() /
+           xt::linalg::dot(previous_gradient, previous_gradient)();
+  }
+};
+} // namespace conjugacy
+} // namespace linesearch
+} // namespace optimize
+} // namespace xts

--- a/CppCore/xtsci/optimize/linesearch/conjugacy/hestenes-stiefel.hpp
+++ b/CppCore/xtsci/optimize/linesearch/conjugacy/hestenes-stiefel.hpp
@@ -16,12 +16,13 @@ namespace optimize {
 namespace linesearch {
 namespace conjugacy {
 template <typename ScalarType>
-class FletcherReeves : public ConjugacyCoefficientStrategy<ScalarType> {
+class HestenesStiefel : public ConjugacyCoefficientStrategy<ScalarType> {
 public:
   ScalarType
   computeBeta(const ConjugacyContext<ScalarType> &ctx) const override {
-    return xt::linalg::dot(ctx.current_gradient, ctx.current_gradient)() /
-           xt::linalg::dot(ctx.previous_gradient, ctx.previous_gradient)();
+    return (xt::linalg::dot(ctx.current_gradient,
+                            ctx.current_gradient - ctx.previous_gradient)() /
+            xt::linalg::dot(ctx.previous_gradient, ctx.previous_gradient)());
   }
 };
 } // namespace conjugacy

--- a/CppCore/xtsci/optimize/linesearch/conjugacy/hybridized_conj.hpp
+++ b/CppCore/xtsci/optimize/linesearch/conjugacy/hybridized_conj.hpp
@@ -1,0 +1,45 @@
+#pragma once
+// MIT License
+// Copyright 2023--present Rohit Goswami <HaoZeke>
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "xtensor-blas/xlinalg.hpp"
+
+#include "xtsci/optimize/linesearch/base.hpp"
+
+namespace xts {
+namespace optimize {
+namespace linesearch {
+namespace conjugacy {
+
+template <typename ScalarType>
+class HybridizedConj : public ConjugacyCoefficientStrategy<ScalarType> {
+  std::reference_wrapper<ConjugacyCoefficientStrategy<ScalarType>> m_ccs1,
+      m_ccs2;
+  std::function<ScalarType(ScalarType, ScalarType)> m_operator;
+
+public:
+  HybridizedConj(
+      ConjugacyCoefficientStrategy<ScalarType> &ccs1,
+      ConjugacyCoefficientStrategy<ScalarType> &ccs2,
+      std::function<ScalarType(ScalarType, ScalarType)> op =
+          [](ScalarType a, ScalarType b) -> ScalarType {
+        return std::max(a, b);
+      })
+      : m_ccs1{ccs1}, m_ccs2{ccs2}, m_operator{op} {}
+
+  ScalarType
+  computeBeta(const ConjugacyContext<ScalarType> &ctx) const override {
+    return m_operator(m_ccs1.get().computeBeta(ctx),
+                      m_ccs2.get().computeBeta(ctx));
+  }
+};
+
+} // namespace conjugacy
+} // namespace linesearch
+} // namespace optimize
+} // namespace xts

--- a/CppCore/xtsci/optimize/linesearch/conjugacy/liu_storey.hpp
+++ b/CppCore/xtsci/optimize/linesearch/conjugacy/liu_storey.hpp
@@ -16,12 +16,13 @@ namespace optimize {
 namespace linesearch {
 namespace conjugacy {
 template <typename ScalarType>
-class FletcherReeves : public ConjugacyCoefficientStrategy<ScalarType> {
+class LiuStorey : public ConjugacyCoefficientStrategy<ScalarType> {
 public:
   ScalarType
   computeBeta(const ConjugacyContext<ScalarType> &ctx) const override {
-    return xt::linalg::dot(ctx.current_gradient, ctx.current_gradient)() /
-           xt::linalg::dot(ctx.previous_gradient, ctx.previous_gradient)();
+    return (xt::linalg::dot(ctx.current_gradient,
+                            ctx.current_gradient - ctx.previous_gradient)() /
+            xt::linalg::dot(ctx.previous_gradient, ctx.previous_gradient)());
   }
 };
 } // namespace conjugacy

--- a/CppCore/xtsci/optimize/linesearch/conjugacy/polak_ribiere.hpp
+++ b/CppCore/xtsci/optimize/linesearch/conjugacy/polak_ribiere.hpp
@@ -19,11 +19,10 @@ template <typename ScalarType>
 class PolakRibiere : public ConjugacyCoefficientStrategy<ScalarType> {
 public:
   ScalarType
-  computeBeta(const xt::xarray<ScalarType> &current_gradient,
-              const xt::xarray<ScalarType> &previous_gradient) const override {
-    return xt::linalg::dot(current_gradient,
-                           current_gradient - previous_gradient)() /
-           xt::linalg::dot(previous_gradient, previous_gradient)();
+  computeBeta(const ConjugacyContext<ScalarType> &ctx) const override {
+    return xt::linalg::dot(ctx.current_gradient,
+                           ctx.current_gradient - ctx.previous_gradient)() /
+           xt::linalg::dot(ctx.previous_gradient, ctx.previous_gradient)();
   }
 };
 } // namespace conjugacy

--- a/CppCore/xtsci/optimize/linesearch/conjugacy/polak_ribiere.hpp
+++ b/CppCore/xtsci/optimize/linesearch/conjugacy/polak_ribiere.hpp
@@ -1,0 +1,32 @@
+#pragma once
+// MIT License
+// Copyright 2023--present Rohit Goswami <HaoZeke>
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "xtensor-blas/xlinalg.hpp"
+
+#include "xtsci/optimize/linesearch/base.hpp"
+
+namespace xts {
+namespace optimize {
+namespace linesearch {
+namespace conjugacy {
+template <typename ScalarType>
+class PolakRibiere : public ConjugacyCoefficientStrategy<ScalarType> {
+public:
+  ScalarType
+  computeBeta(const xt::xarray<ScalarType> &current_gradient,
+              const xt::xarray<ScalarType> &previous_gradient) const override {
+    return xt::linalg::dot(current_gradient,
+                           current_gradient - previous_gradient)() /
+           xt::linalg::dot(previous_gradient, previous_gradient)();
+  }
+};
+} // namespace conjugacy
+} // namespace linesearch
+} // namespace optimize
+} // namespace xts

--- a/CppCore/xtsci/optimize/minimize/cg.hpp
+++ b/CppCore/xtsci/optimize/minimize/cg.hpp
@@ -17,9 +17,13 @@ template <typename ScalarType>
 class ConjugateGradientOptimizer
     : public linesearch::LineSearchOptimizer<ScalarType> {
 public:
+  std::reference_wrapper<linesearch::ConjugacyCoefficientStrategy<ScalarType>>
+      m_conj;
   ConjugateGradientOptimizer(
-      linesearch::LineSearchStrategy<ScalarType> &strategy)
-      : linesearch::LineSearchOptimizer<ScalarType>(strategy) {}
+      linesearch::LineSearchStrategy<ScalarType> &strategy,
+      linesearch::ConjugacyCoefficientStrategy<ScalarType> &conjugacy_strategy)
+      : linesearch::LineSearchOptimizer<ScalarType>(strategy),
+        m_conj(conjugacy_strategy) {}
 
   OptimizeResult<ScalarType>
   optimize(const ObjectiveFunction<ScalarType> &func,
@@ -72,9 +76,7 @@ public:
         break;
       }
 
-      auto beta_expr = xt::linalg::dot(new_gradient, new_gradient) /
-                       xt::linalg::dot(gradient, gradient);
-      ScalarType beta = beta_expr();
+      ScalarType beta = m_conj.get().computeBeta(new_gradient, gradient);
 
       xt::noalias(direction) = -new_gradient + beta * direction;
       gradient = new_gradient; // Direct assignment (assumes ownership transfer

--- a/CppCore/xtsci/optimize/minimize/cg.hpp
+++ b/CppCore/xtsci/optimize/minimize/cg.hpp
@@ -76,7 +76,8 @@ public:
         break;
       }
 
-      ScalarType beta = m_conj.get().computeBeta(new_gradient, gradient);
+      ScalarType beta = m_conj.get().computeBeta(
+          {.current_gradient = new_gradient, .previous_gradient = gradient});
 
       xt::noalias(direction) = -new_gradient + beta * direction;
       gradient = new_gradient; // Direct assignment (assumes ownership transfer

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('xtsci-optimize', 'cpp',
   version : '0.0.1',
   default_options : ['warning_level=3',
-                     'cpp_std=c++17',
+                     'cpp_std=c++20',
                      'debug=true',
                      'buildtype=debug'])
 

--- a/readme.org
+++ b/readme.org
@@ -24,6 +24,8 @@ The heart of the library is the ~xts~ namespace, with functions further
 demarcated according to the relevant ~scipy~ modules e.g.
 ~xts::optimize~.
 
+- Note that this uses designated initializers, a C++20 feature.
+
 ** Provenance
 These are constructed mostly with the notation of the Nocedal and Wright book.
 


### PR DESCRIPTION
Closes #5 by adding:
- Fletcher Reeves
- Polak Ribiere
- Hestenes-Stiefel
- Liu-Storey

Along with an operator-base aggregator which can be used to combine any two of them with a unary op.

```cpp
  xts::optimize::linesearch::conjugacy::FletcherReeves<double> fletcherreeves;
  xts::optimize::linesearch::conjugacy::PolakRibiere<double> polakribiere;
  xts::optimize::linesearch::conjugacy::HestenesStiefel<double> hestenesstiefel;
  xts::optimize::linesearch::conjugacy::LiuStorey<double> liustorey;
  xts::optimize::linesearch::conjugacy::HybridizedConj<double> hybrid_min(
      hestenesstiefel, polakribiere,
      [](double a, double b) -> double { return std::min(a, b); });

  xts::optimize::minimize::ConjugateGradientOptimizer<double> cgopt(
      moorethuente, hybrid_min);
```