### PR TITLE
feat: manifold waist with Euclidean proj/retr/transp

### DIFF
--- a/include/xts.h
+++ b/include/xts.h
@@ -46,7 +46,7 @@ typedef struct xts_abi_stamp_t {
 } xts_abi_stamp_t;
 
 #define XTS_ABI_VERSION_MAJOR 1
-#define XTS_ABI_VERSION_MINOR 7
+#define XTS_ABI_VERSION_MINOR 8
 #define XTS_ABI_LAYOUT_REVISION 2
 
 /** Solver selector. \c XTS_LBFGS is the production unconstrained method. */
@@ -186,6 +186,15 @@ void xts_solver_set_cautious(xts_solver_t *solver, double eps, double alpha);
 /** HiGHS feasible-set step. Nonzero enables it. Returns 0, or 1 if this
  *  build has no highs feature. */
 int32_t xts_solver_set_highs(xts_solver_t *solver, int32_t enabled);
+/** Embedded manifold. Euclidean is the default. */
+typedef enum xts_manifold_t {
+    XTS_MANIFOLD_EUCLIDEAN = 0,
+    XTS_MANIFOLD_SPHERE = 1,
+    XTS_MANIFOLD_SO3 = 2,
+    XTS_MANIFOLD_STIEFEL = 3,
+    XTS_MANIFOLD_SE3 = 4
+} xts_manifold_t;
+void xts_solver_set_manifold(xts_solver_t *solver, xts_manifold_t manifold);
 /**
  * One outer iteration: direction, line search, curvature update.
  * \a eval and \a grad are valid for this call only. \a x is in/out.

--- a/include/xts/optimize.hpp
+++ b/include/xts/optimize.hpp
@@ -203,6 +203,7 @@ public:
         xts_solver_set_cautious(ptr_, eps, alpha);
     }
     int set_highs(bool on) { return xts_solver_set_highs(ptr_, on ? 1 : 0); }
+    void set_manifold(xts_manifold_t m) { xts_solver_set_manifold(ptr_, m); }
 
     Report step(xts_eval_fn eval, xts_grad_fn grad, void* user,
                 DLManagedTensorVersioned* x) {

--- a/src/accept.rs
+++ b/src/accept.rs
@@ -6,6 +6,7 @@ use eindir_core::DifferentiableObjective;
 use ndarray::Array1;
 
 use crate::control::Control;
+use crate::manifold::{Manifold, ManifoldKind};
 use crate::step::{scale_step, scale_step_atom};
 
 const ENERGY_RISE: f64 = 1.0e-8;
@@ -30,11 +31,13 @@ fn trial_point<O>(
     alpha: f64,
     control: &Control,
     atom_maxmove: Option<f64>,
+    manifold: ManifoldKind,
 ) -> Array1<f64>
 where
     O: DifferentiableObjective<f64> + ?Sized,
 {
-    let mut trial = pos + &(dir * alpha);
+    let step = dir * alpha;
+    let mut trial = manifold.retract(pos, &step);
     if let Some(cap) = atom_maxmove {
         scale_step_atom(pos, &mut trial, cap);
     } else if let Some(cap) = control.maxmove {
@@ -61,13 +64,14 @@ pub(crate) fn accept_step<O>(
     accept: Accept,
     e_hist: &mut VecDeque<f64>,
     atom_maxmove: Option<f64>,
+    manifold: ManifoldKind,
 ) -> (Array1<f64>, f64, Array1<f64>, bool)
 where
     O: DifferentiableObjective<f64> + ?Sized,
 {
     match accept {
         Accept::None => {
-            let trial = trial_point(obj, pos, dir, 1.0, control, atom_maxmove);
+            let trial = trial_point(obj, pos, dir, 1.0, control, atom_maxmove, manifold);
             let (ft, gt) = obj.value_and_gradient(trial.view());
             push_energy(e_hist, ft);
             (trial, ft, gt, true)
@@ -81,7 +85,7 @@ where
             }
             let mut alpha = 1.0;
             for _ in 0..10 {
-                let trial = trial_point(obj, pos, dir, alpha, control, atom_maxmove);
+                let trial = trial_point(obj, pos, dir, alpha, control, atom_maxmove, manifold);
                 let (ft, gt) = obj.value_and_gradient(trial.view());
                 if ft - ref_e <= ENERGY_RISE {
                     push_energy(e_hist, ft);
@@ -90,7 +94,7 @@ where
                 alpha *= 0.5;
             }
             let sd = grad.mapv(|g| -g);
-            let trial = trial_point(obj, pos, &sd, 0.1, control, atom_maxmove);
+            let trial = trial_point(obj, pos, &sd, 0.1, control, atom_maxmove, manifold);
             let (ft, gt) = obj.value_and_gradient(trial.view());
             push_energy(e_hist, ft);
             (trial, ft, gt, true)
@@ -102,7 +106,7 @@ where
 mod tests {
     use super::*;
     use eindir_core::{Bounds, DifferentiableObjective, Gradient, Objective};
-    use ndarray::{array, ArrayView1};
+    use ndarray::{ArrayView1, array};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     struct CountQuad {
@@ -165,6 +169,7 @@ mod tests {
             Accept::None,
             &mut hist,
             None,
+            ManifoldKind::Euclidean,
         );
         assert!(moved);
         assert!((x[0] - 2.0).abs() < 1e-15);
@@ -191,6 +196,7 @@ mod tests {
             Accept::Energy,
             &mut hist,
             None,
+            ManifoldKind::Euclidean,
         );
         // 10 rejected halvings + one short steepest fallback.
         assert_eq!(obj.evals.load(Ordering::Relaxed), 11);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -18,8 +18,8 @@ use eindir_core::ffi::{
 use ndarray::{Array1, Array2};
 
 use crate::{
-    Accept, Control, HessianOracle, LineSearch, Method, NewtonKind, Oracle, QnStep, Solver,
-    minimize_method, minimize_method_hess,
+    Accept, Control, HessianOracle, LineSearch, ManifoldKind, Method, NewtonKind, Oracle, QnStep,
+    Solver, minimize_method, minimize_method_hess,
 };
 
 /// Status codes. 0 is success, matching metatensor / eindir.
@@ -49,7 +49,7 @@ pub struct xts_abi_stamp_t {
 }
 
 pub const XTS_ABI_VERSION_MAJOR: u16 = 1;
-pub const XTS_ABI_VERSION_MINOR: u16 = 7;
+pub const XTS_ABI_VERSION_MINOR: u16 = 8;
 pub const XTS_ABI_LAYOUT_REVISION: u16 = 2;
 
 /// Method tag. Keep this a closed C enum; Rust [`Method`] is the source.
@@ -933,6 +933,36 @@ pub unsafe extern "C" fn xts_solver_set_highs(solver: *mut xts_solver_t, enabled
         set_last_error("xts_solver_set_highs: build has no highs feature");
         1
     }
+}
+
+/// Embedded manifold. Tokens other than Euclidean are filled on
+/// `feat/manifold-*` branches.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum xts_manifold_t {
+    XTS_MANIFOLD_EUCLIDEAN = 0,
+    XTS_MANIFOLD_SPHERE = 1,
+    XTS_MANIFOLD_SO3 = 2,
+    XTS_MANIFOLD_STIEFEL = 3,
+    XTS_MANIFOLD_SE3 = 4,
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xts_solver_set_manifold(
+    solver: *mut xts_solver_t,
+    manifold: xts_manifold_t,
+) {
+    if solver.is_null() {
+        return;
+    }
+    let kind = match manifold {
+        xts_manifold_t::XTS_MANIFOLD_SPHERE => ManifoldKind::Sphere,
+        xts_manifold_t::XTS_MANIFOLD_SO3 => ManifoldKind::So3,
+        xts_manifold_t::XTS_MANIFOLD_STIEFEL => ManifoldKind::Stiefel,
+        xts_manifold_t::XTS_MANIFOLD_SE3 => ManifoldKind::Se3,
+        xts_manifold_t::XTS_MANIFOLD_EUCLIDEAN => ManifoldKind::Euclidean,
+    };
+    unsafe { (*solver).solver.set_manifold(kind) };
 }
 
 /// One outer iteration. `x` is in/out. Callbacks live for this call only.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ pub mod lbfgs;
 /// L-BFGS quadratic model solved by HiGHS.
 #[cfg(feature = "highs")]
 pub mod lbfgs_qp;
+/// Embedded Riemannian manifolds (manopt_cpp proj / retr / transp).
+pub mod manifold;
 mod minimize;
 /// Shifted Newton and Banerjee RFO on a dense Hessian.
 pub mod newton;
@@ -61,6 +63,7 @@ pub use lbfgs::{GradNorm, Lbfgs};
 #[cfg(feature = "highs")]
 pub use lbfgs_qp::HighsStep;
 pub use linesearch::LineSearch;
+pub use manifold::{Manifold, ManifoldKind};
 pub use method::Method;
 pub use minimize::{minimize, minimize_method, minimize_method_hess};
 pub use newton::{HessianObjective, HessianOracle, NewtonKind, minimize_newton};

--- a/src/manifold/euclidean.rs
+++ b/src/manifold/euclidean.rs
@@ -1,0 +1,43 @@
+//! Ambient Euclidean space. Identity projection and retraction.
+
+use ndarray::Array1;
+
+use super::Manifold;
+
+/// Unconstrained Euclidean geometry.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Euclidean;
+
+impl Manifold for Euclidean {
+    fn project(&self, _x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        v.clone()
+    }
+
+    fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        x + v
+    }
+
+    fn transport(
+        &self,
+        _x_from: &Array1<f64>,
+        _x_to: &Array1<f64>,
+        v: &Array1<f64>,
+    ) -> Array1<f64> {
+        v.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn retract_is_translation() {
+        let x = array![1.0, 2.0];
+        let v = array![0.5, -1.0];
+        let y = Euclidean.retract(&x, &v);
+        assert!((y[0] - 1.5).abs() < 1e-15);
+        assert!((y[1] - 1.0).abs() < 1e-15);
+    }
+}

--- a/src/manifold/mod.rs
+++ b/src/manifold/mod.rs
@@ -1,0 +1,69 @@
+//! Embedded Riemannian manifolds (manopt_cpp / ROPTLIB waist).
+//!
+//! Absil, Mahony, Sepulchre, *Optimization Algorithms on Matrix
+//! Manifolds*, <https://doi.org/10.1515/9781400830244>.
+//! Boumal, *An Introduction to Optimization on Smooth Manifolds*,
+//! <https://doi.org/10.1017/9781009166164>.
+//! manopt_cpp: `proj`, `retr`, `transp` on an embedded Euclidean vector.
+
+use ndarray::Array1;
+
+mod euclidean;
+
+pub use euclidean::Euclidean;
+
+/// Which embedded geometry a session retracts onto.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ManifoldKind {
+    /// Ambient Euclidean. Today's path.
+    #[default]
+    Euclidean,
+    /// Unit sphere \(S^{n-1}\).
+    Sphere,
+    /// Rotation matrices SO(3), 9-vector row-major.
+    So3,
+    /// Stiefel \(\mathrm{St}(n,p)\). `p` from [`ManifoldKind::stiefel_p`].
+    Stiefel,
+    /// Rigid motions SE(3): 3x3 row-major then translation (12).
+    Se3,
+}
+
+impl ManifoldKind {
+    /// Stiefel column count. `p = 1` is the sphere.
+    pub fn stiefel_p(self) -> usize {
+        1
+    }
+}
+
+/// manopt_cpp `AbstractManifold` on a rank-1 f64 vector.
+pub trait Manifold {
+    /// Tangent projection of an ambient vector at `x`.
+    fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64>;
+    /// Retraction of the tangent step `v` at `x`.
+    fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64>;
+    /// Vector transport of `v` from `x_from` to `x_to`.
+    fn transport(&self, x_from: &Array1<f64>, x_to: &Array1<f64>, v: &Array1<f64>) -> Array1<f64>;
+}
+
+impl Manifold for ManifoldKind {
+    fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        match self {
+            Self::Euclidean => Euclidean.project(x, v),
+            _ => Euclidean.project(x, v),
+        }
+    }
+
+    fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        match self {
+            Self::Euclidean => Euclidean.retract(x, v),
+            _ => Euclidean.retract(x, v),
+        }
+    }
+
+    fn transport(&self, x_from: &Array1<f64>, x_to: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        match self {
+            Self::Euclidean => Euclidean.transport(x_from, x_to, v),
+            _ => Euclidean.transport(x_from, x_to, v),
+        }
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,6 +15,7 @@ use crate::error::{Error, Result};
 use crate::fire::{FireState, fire_after_v1, fire_displacement};
 use crate::lbfgs::{GradNorm, Lbfgs};
 use crate::linesearch::LineSearch;
+use crate::manifold::{Manifold, ManifoldKind};
 use crate::method::Method;
 use crate::newton::{HessianObjective, NewtonKind, rfo_direction, shifted_newton};
 use crate::nlcg::{Conjugacy, ConjugacyContext, Restart};
@@ -40,6 +41,7 @@ pub struct Solver {
     e_hist: VecDeque<f64>,
     atom_maxmove: Option<f64>,
     project_rigid: bool,
+    manifold: ManifoldKind,
     #[cfg(feature = "highs")]
     highs: bool,
     last_pos: Option<Array1<f64>>,
@@ -120,6 +122,7 @@ impl Solver {
             e_hist: VecDeque::new(),
             atom_maxmove: None,
             project_rigid: false,
+            manifold: ManifoldKind::Euclidean,
             #[cfg(feature = "highs")]
             highs: false,
             last_pos: None,
@@ -152,6 +155,14 @@ impl Solver {
     /// eOn `lbfgs_project_rigid`. Isolated clusters only.
     pub fn set_project_rigid(&mut self, enabled: bool) {
         self.project_rigid = enabled;
+    }
+
+    /// Embedded manifold for project / retract / transport.
+    pub fn set_manifold(&mut self, kind: ManifoldKind) {
+        if kind != self.manifold {
+            self.forget();
+        }
+        self.manifold = kind;
     }
 
     /// Al-Baali extra-updates on the newest L-BFGS pair.
@@ -335,6 +346,7 @@ impl Solver {
                     self.accept,
                     &mut self.e_hist,
                     None,
+                    self.manifold,
                 );
                 if moved {
                     *x = npos;
@@ -369,6 +381,7 @@ impl Solver {
         if self.project_rigid {
             project_out_rot_trans(&mut dir, x.view());
         }
+        dir = self.manifold.project(x, &dir);
         let old = x.clone();
         let gold = grad.clone();
         let (npos, nval, ngrad, moved) = accept_step(
@@ -381,6 +394,7 @@ impl Solver {
             self.accept,
             &mut self.e_hist,
             self.atom_maxmove,
+            self.manifold,
         );
         if moved {
             *x = npos;

--- a/tests/c_abi.rs
+++ b/tests/c_abi.rs
@@ -448,7 +448,7 @@ fn fused_evalgrad_is_one_callback_per_oracle() {
 fn abi_stamp_identifies_this_optimizer_layout() {
     let stamp = xts_abi_stamp();
     assert_eq!(stamp.abi_major, 1);
-    assert_eq!(stamp.abi_minor, 7);
+    assert_eq!(stamp.abi_minor, 8);
     assert_eq!(stamp.layout_revision, 2);
     assert_eq!(unsafe { xts_abi_compatible(&stamp) }, 1);
 }

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -131,6 +131,16 @@ fn lbfgs_newton_on_a_supplied_hessian_kills_a_quadratic() {
 }
 
 #[test]
+fn default_manifold_is_euclidean() {
+    let obj = Rosenbrock::<2>::new();
+    let mut x = array![-1.2, 1.0];
+    let mut solver = Solver::new(Method::lbfgs(), control(), 2).with_gtol(1e-8);
+    solver.set_manifold(xtsci_optimize::ManifoldKind::Euclidean);
+    let rep = solver.step(&obj, &mut x).unwrap();
+    assert!(rep.grad_norm.is_finite());
+}
+
+#[test]
 fn nlcg_second_step_is_not_steepest() {
     let obj = Rosenbrock::<2>::new();
     let mut a = array![-1.2, 1.0];


### PR DESCRIPTION
`xts_solver_set_manifold` is a session setter. The contract is manopt_cpp `project` / `retract` / `transport` on a rank-1 f64 vector.

Euclidean is the identity, so existing eindir / rgpot / eOn paths do not change until a host calls the setter.

Absil, Mahony, Sepulchre doi:10.1515/9781400830244. Boumal doi:10.1017/9781009166164.