### PR TITLE
feat: sphere proj, retract, and transport

### DIFF
--- a/src/manifold/mod.rs
+++ b/src/manifold/mod.rs
@@ -9,8 +9,10 @@
 use ndarray::Array1;
 
 mod euclidean;
+mod sphere;
 
 pub use euclidean::Euclidean;
+pub use sphere::Sphere;
 
 /// Which embedded geometry a session retracts onto.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -49,6 +51,7 @@ impl Manifold for ManifoldKind {
     fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
         match self {
             Self::Euclidean => Euclidean.project(x, v),
+            Self::Sphere => Sphere.project(x, v),
             _ => Euclidean.project(x, v),
         }
     }
@@ -56,6 +59,7 @@ impl Manifold for ManifoldKind {
     fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
         match self {
             Self::Euclidean => Euclidean.retract(x, v),
+            Self::Sphere => Sphere.retract(x, v),
             _ => Euclidean.retract(x, v),
         }
     }
@@ -63,6 +67,7 @@ impl Manifold for ManifoldKind {
     fn transport(&self, x_from: &Array1<f64>, x_to: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
         match self {
             Self::Euclidean => Euclidean.transport(x_from, x_to, v),
+            Self::Sphere => Sphere.transport(x_from, x_to, v),
             _ => Euclidean.transport(x_from, x_to, v),
         }
     }

--- a/src/manifold/sphere.rs
+++ b/src/manifold/sphere.rs
@@ -1,0 +1,67 @@
+//! Unit sphere \(S^{n-1}\). manopt_cpp `Sphere`.
+//!
+//! Projection \(v - (x\cdot v)x\). Retraction \((x+v)/\|x+v\|\).
+//! Transport is projection at the arrival point.
+
+use ndarray::Array1;
+
+use super::Manifold;
+
+/// Unit sphere in the ambient Euclidean metric.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Sphere;
+
+fn dot(a: &Array1<f64>, b: &Array1<f64>) -> f64 {
+    a.iter().zip(b.iter()).map(|(u, v)| u * v).sum()
+}
+
+fn nrm(a: &Array1<f64>) -> f64 {
+    dot(a, a).sqrt()
+}
+
+impl Manifold for Sphere {
+    fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        let s = dot(x, v);
+        Array1::from_iter(x.iter().zip(v.iter()).map(|(xi, vi)| vi - s * xi))
+    }
+
+    fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        let y = x + v;
+        let n = nrm(&y);
+        if n <= 1e-16 {
+            let n0 = nrm(x);
+            if n0 <= 1e-16 {
+                return x.clone();
+            }
+            return x / n0;
+        }
+        y / n
+    }
+
+    fn transport(&self, _x_from: &Array1<f64>, x_to: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        self.project(x_to, v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn project_is_orthogonal_to_x() {
+        let x = array![1.0, 0.0, 0.0];
+        let v = array![2.0, 3.0, 4.0];
+        let t = Sphere.project(&x, &v);
+        assert!(dot(&x, &t).abs() < 1e-15);
+        assert!((t[1] - 3.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn retract_stays_on_the_sphere() {
+        let x = array![0.0, 1.0, 0.0];
+        let v = array![0.1, 0.0, -0.2];
+        let y = Sphere.retract(&x, &v);
+        assert!((nrm(&y) - 1.0).abs() < 1e-14);
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -511,6 +511,7 @@ impl Solver {
             });
         }
 
+        let start = x.clone();
         match &mut self.inner {
             Inner::Lbfgs(solver) => {
                 solver.step_objective(
@@ -716,6 +717,15 @@ impl Solver {
                 }
             }
             Inner::Pso { .. } | Inner::Newton { .. } | Inner::Dogleg { .. } => unreachable!(),
+        }
+
+        let delta = &*x - &start;
+        let y = self.manifold.retract(&start, &delta);
+        if y.iter().zip(x.iter()).any(|(a, b)| (*a - *b).abs() > 1e-15) {
+            *x = y;
+            let ev = obj.value_and_gradient(x.view());
+            value = ev.0;
+            grad = ev.1;
         }
 
         self.remember(x, value, &grad);

--- a/src/session.rs
+++ b/src/session.rs
@@ -707,6 +707,7 @@ impl Solver {
                     self.accept,
                     &mut self.e_hist,
                     self.atom_maxmove,
+                    self.manifold,
                 );
                 *x = npos;
                 value = nval;

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -131,6 +131,62 @@ fn lbfgs_newton_on_a_supplied_hessian_kills_a_quadratic() {
 }
 
 #[test]
+fn sphere_rayleigh_stays_on_the_sphere() {
+    use eindir_core::{Bounds, DifferentiableObjective, Gradient, Objective};
+    use ndarray::ArrayView1;
+    use xtsci_optimize::ManifoldKind;
+
+    struct Ray;
+    impl Objective<f64> for Ray {
+        fn dim(&self) -> usize {
+            3
+        }
+        fn bounds(&self) -> &Bounds<f64> {
+            use std::sync::OnceLock;
+            static B: OnceLock<Bounds<f64>> = OnceLock::new();
+            B.get_or_init(|| Bounds::new(array![-2.0, -2.0, -2.0], array![2.0, 2.0, 2.0], 0.0))
+        }
+        fn eval(&self, x: ArrayView1<f64>) -> f64 {
+            0.5 * (x[0] * x[0] + 2.0 * x[1] * x[1] + 3.0 * x[2] * x[2])
+        }
+    }
+    impl Gradient<f64> for Ray {
+        fn dim(&self) -> usize {
+            3
+        }
+        fn grad(&self, x: ArrayView1<f64>) -> ndarray::Array1<f64> {
+            array![x[0], 2.0 * x[1], 3.0 * x[2]]
+        }
+    }
+    impl DifferentiableObjective<f64> for Ray {
+        fn value_and_gradient(&self, x: ArrayView1<f64>) -> (f64, ndarray::Array1<f64>) {
+            (self.eval(x), self.grad(x))
+        }
+    }
+
+    let obj = Ray;
+    let n = (1.0_f64 + 1.0 + 1.0).sqrt();
+    let mut x = array![1.0 / n, 1.0 / n, 1.0 / n];
+    let mut solver = Solver::new(
+        Method::Steepest,
+        Control {
+            maxiter: 40,
+            gtol: 1e-8,
+            istep: 0.2,
+            maxmove: None,
+        },
+        3,
+    );
+    solver.set_manifold(ManifoldKind::Sphere);
+    solver.set_accept(xtsci_optimize::Accept::None);
+    for _ in 0..40 {
+        let _ = solver.step(&obj, &mut x).unwrap();
+        let nrm = (x[0] * x[0] + x[1] * x[1] + x[2] * x[2]).sqrt();
+        assert!((nrm - 1.0).abs() < 1e-10, "left the sphere {x:?}");
+    }
+}
+
+#[test]
 fn default_manifold_is_euclidean() {
     let obj = Rosenbrock::<2>::new();
     let mut x = array![-1.2, 1.0];


### PR DESCRIPTION
`S^{n-1}`. Projection is `v - (x·v)x`. Retraction is `(x+v)/||x+v||`. Transport is projection at the arrival point.

This is a unit-vector embedding. A 3N molecular cluster is `rigid_quotient` (`R^{3N}/SE(3)`), not `S^{3N-1}`.