### PR TITLE
feat: Stiefel St(n,1) as the sphere

### DIFF
--- a/src/manifold/stiefel.rs
+++ b/src/manifold/stiefel.rs
@@ -1,0 +1,23 @@
+//! Stiefel \(\mathrm{St}(n,1)\): columns of an \(n\times p\) frame, \(p=1\) is the sphere.
+
+use ndarray::Array1;
+
+use super::{Manifold, sphere::Sphere};
+
+/// Stiefel with \(p=1\) (sphere). Wider frames land on a later branch.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Stiefel;
+
+impl Manifold for Stiefel {
+    fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        Sphere.project(x, v)
+    }
+
+    fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        Sphere.retract(x, v)
+    }
+
+    fn transport(&self, x_from: &Array1<f64>, x_to: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        Sphere.transport(x_from, x_to, v)
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -707,6 +707,7 @@ impl Solver {
                     self.accept,
                     &mut self.e_hist,
                     self.atom_maxmove,
+                    self.manifold,
                 );
                 *x = npos;
                 value = nval;


### PR DESCRIPTION
`St(n,1)` is one orthonormal column, so it is the sphere. `p > 1` is not a length-`n` token.

A 3N cluster is `rigid_quotient`, not `St(3N, 1)`.