### PR TITLE
feat: Sella R^{3N}/SE(3) and Page-McIver Eckart

### DIFF
--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -40,6 +40,9 @@ ISBN). Do not invent DOIs.
 | Boumal 2023 | 10.1017/9781009166164 | An Introduction to Optimization on Smooth Manifolds |
 | Manopt 2014 | 10.5555/2627435.2638581 | Manopt, a matlab toolbox for optimization on manifolds |
 | ROPTLIB | 10.1145/3218822 | ROPTLIB |
+| Sella Hermes–Sarsfield–Zádor 2022 | 10.1021/acs.jctc.2c00395 | Sella, an Open-Source Automation-Friendly Molecular Saddle Point Optimizer |
+| Page–McIver 1988 | 10.1063/1.454172 | On evaluating the reaction path Hamiltonian |
+| Ishida–Morokuma–Komornicki 1977 | 10.1063/1.434152 | The intrinsic reaction coordinate |
 
 Polak-Ribiere 1969 and Hestenes-Stiefel 1952: cite the paper/book
 title in rustdoc if no DOI is on this list. Do not mint a DOI.

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -6,9 +6,16 @@
 
 ** Unreleased
 
-Embedded manifolds on ~xts_solver_set_manifold~: Euclidean
-(default), sphere, SO(3), Stiefel ~St(n,1)~, SE(3). Hourglass
-mark and the Diataxis book under ~docs/orgmode/~.
+Molecular manifolds: ~rigid_quotient~ is Sella Cartesian
+~R^{3N}/SE(3)~ (~fix_translation~ + ~fix_rotation~);
+~mw_rigid~ is the Page–McIver / Sella IRC Eckart metric on the
+same quotient (~xts_solver_set_masses~). SO(3) is length 9 and
+SE(3) is length 12; a 3N cluster is rejected rather than packed
+or prefix-interpreted. ~abi_minor~ 9.
+
+Embedded manopt tokens: Euclidean (default), sphere, SO(3),
+Stiefel ~St(n,1)~, SE(3). Hourglass mark and the Diataxis book
+under ~docs/orgmode/~.
 
 ** 0.2.0
 

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -11,7 +11,9 @@ Molecular manifolds: ~rigid_quotient~ is Sella Cartesian
 ~mw_rigid~ is the Page–McIver / Sella IRC Eckart metric on the
 same quotient (~xts_solver_set_masses~). SO(3) is length 9 and
 SE(3) is length 12; a 3N cluster is rejected rather than packed
-or prefix-interpreted. ~abi_minor~ 9.
+or prefix-interpreted. Periodic bulk sets
+~xts_solver_set_periodic~: Sella ~proj_rot = false~, quotient
+~R^{3N}/T(3)~. Isolated stays ~R^{3N}/SE(3)~. ~abi_minor~ 10.
 
 Embedded manopt tokens: Euclidean (default), sphere, SO(3),
 Stiefel ~St(n,1)~, SE(3). Hourglass mark and the Diataxis book

--- a/docs/orgmode/howto/c-abi.org
+++ b/docs/orgmode/howto/c-abi.org
@@ -64,5 +64,9 @@ the same ~xts_minimize~ entry. There is no solver in the header.
 xts_solver_set_manifold(s, XTS_MANIFOLD_SPHERE);
 #+end_src
 
-Tokens: ~XTS_MANIFOLD_EUCLIDEAN~ (default), ~SPHERE~, ~SO3~,
-~STIEFEL~, ~SE3~. See [[file:manifolds.org][retract onto an embedded manifold]].
+Tokens: ~XTS_MANIFOLD_EUCLIDEAN~ (default), ~RIGID_QUOTIENT~
+(~R^{3N}/SE(3)~, Sella Cartesian), ~MW_RIGID~ (Page–McIver /
+Sella IRC Eckart), ~SPHERE~, ~SO3~ (length 9), ~STIEFEL~
+(~St(n,1)~), ~SE3~ (length 12). See
+[[file:manifolds.org][retract onto an embedded manifold]].
+~xts_solver_set_masses~ supplies N atomic masses for ~MW_RIGID~.

--- a/docs/orgmode/howto/manifolds.org
+++ b/docs/orgmode/howto/manifolds.org
@@ -84,11 +84,11 @@ Changing the manifold drops method memory (~forget~).
 
 ** Packing notes
 
-- ~RigidQuotient~ is 3N Cartesians. The tangent is the kernel of
-  three translations and three infinitesimal rotations. Sella
-  TRICs (bonds / angles / dihedrals plus fragment T/R) are a
-  different *chart* of the same physical manifold, not a
-  different packing here.
+- ~RigidQuotient~ is 3N Cartesians. Isolated: kernel of three
+  translations and three infinitesimal rotations
+  (~R^{3N}/SE(3)~). Periodic: Sella ~proj_rot = false~, so only
+  translations (~R^{3N}/T(3)~) via ~xts_solver_set_periodic~.
+  TRICs are a different chart, not a different packing here.
 - ~MwRigid~ is the same 3N packing. Masses are per atom (length
   N). The IRC path itself is steepest descent in that metric,
   not a separate token.

--- a/docs/orgmode/howto/manifolds.org
+++ b/docs/orgmode/howto/manifolds.org
@@ -26,10 +26,26 @@ vector: ~project~, ~retract~, ~transport~. Citations:
 | Token | Packing | Retraction |
 |---+---|---|
 | ~Euclidean~ | length ~n~ | ~x + v~ |
+| ~RigidQuotient~ | 3N Cartesians, N >= 2 | horizontal lift ~x + v~ |
+| ~MwRigid~ | same; masses on the session | same; Eckart inner product |
 | ~Sphere~ | unit vector, length ~n~ | ~(x+v)/||x+v||~ |
 | ~So3~ | row-major ~R~, length 9 | QR with positive diagonal |
 | ~Stiefel~ | ~St(n,1)~: same as the sphere | same as the sphere |
 | ~Se3~ | row-major ~R~ then ~t~, length 12 | SO(3) on the rotation, Euclidean on ~t~ |
+
+An isolated molecule or cluster lives on ~RigidQuotient~
+(~R^{3N}/SE(3)~): Sella Cartesian ~fix_translation~ plus
+~fix_rotation~ (Hermes, Sarsfield, Zádor, JCTC 2022,
+doi:10.1021/acs.jctc.2c00395). ~MwRigid~ is the same quotient
+with the Page–McIver mass-weighted metric used by Sella IRC and
+gpr_optim ~IRCDriver~ (doi:10.1063/1.454172,
+doi:10.1063/1.434152). Call ~set_masses~ with N atomic masses;
+unit mass makes ~MwRigid~ identical to ~RigidQuotient~.
+
+~Sphere~, ~So3~, ~Stiefel~, and ~Se3~ are matrix-manifold
+embeddings. ~So3~ rejects any length other than 9. ~Se3~ rejects
+any length other than 12. They do not pack or prefix-interpret a
+3N cluster.
 
 Euclidean is the default. Existing eOn / rgpot / eindir paths do
 not change until a host calls the setter.
@@ -54,6 +70,9 @@ accept rule.
 ** C
 
 #+begin_src c
+xts_solver_set_manifold(s, XTS_MANIFOLD_RIGID_QUOTIENT);
+xts_solver_set_manifold(s, XTS_MANIFOLD_MW_RIGID);
+xts_solver_set_masses(s, masses, n_atoms);
 xts_solver_set_manifold(s, XTS_MANIFOLD_SPHERE);
 xts_solver_set_manifold(s, XTS_MANIFOLD_SO3);
 xts_solver_set_manifold(s, XTS_MANIFOLD_STIEFEL);
@@ -65,10 +84,19 @@ Changing the manifold drops method memory (~forget~).
 
 ** Packing notes
 
+- ~RigidQuotient~ is 3N Cartesians. The tangent is the kernel of
+  three translations and three infinitesimal rotations. Sella
+  TRICs (bonds / angles / dihedrals plus fragment T/R) are a
+  different *chart* of the same physical manifold, not a
+  different packing here.
+- ~MwRigid~ is the same 3N packing. Masses are per atom (length
+  N). The IRC path itself is steepest descent in that metric,
+  not a separate token.
 - ~So3~ is a 9-vector, row-major. The tangent projection returns
   the embedded vector ~R Omega~, not the skew factor alone.
 - ~Se3~ is twelve numbers: the same 9-vector, then a translation.
-  Rigid projection on ~R^{3N}~ (~set_project_rigid~) is a
-  different operation and stays off by default.
+  It is one rigid body, not N atoms.
 - ~Stiefel~ is ~St(n,1)~. A frame with ~p > 1~ is not a length
   token: ~n p~ does not name ~p~.
+- ~set_project_rigid~ is the same horizontal projection as
+  ~RigidQuotient~ and stays available on Euclidean.

--- a/docs/orgmode/howto/session.org
+++ b/docs/orgmode/howto/session.org
@@ -64,7 +64,8 @@ together is not asked twice.
 | ~set_extra_updates~ | Al-Baali extra L-BFGS pairs |
 | ~set_cautious~ | Li--Fukushima pair filter |
 | ~set_highs~ | Feasible-set QP; returns 1 without ~--features highs~ |
-| ~set_manifold~ | Embedded geometry; Euclidean is the default |
+| ~set_manifold~ | Embedded geometry; ~rigid_quotient~ for 3N clusters |
+| ~set_masses~ | Per-atom masses for ~mw_rigid~ (Page–McIver) |
 
 ** When to use ~xts_minimize~ instead
 

--- a/docs/orgmode/reference/architecture.org
+++ b/docs/orgmode/reference/architecture.org
@@ -23,8 +23,8 @@ Rust, C sees a small ABI, C++ is a header wrapper.
 +-----------------------------------------------+
 |  Rust core                                    |
 |  Solver / Lbfgs / NLCG / BFGS / Newton        |
-|  Manifold (Euclidean, Sphere, SO3, Stiefel,   |
-|            SE3)                               |
+|  Manifold (Euclidean, RigidQuotient, MwRigid) |
+|  Sphere / SO3 / Stiefel / SE3 embeddings      |
 |  LineSearch (Brent, Armijo, Goldstein, Wolfe) |
 |  eindir DifferentiableObjective               |
 +-----------------------------------------------+
@@ -43,7 +43,7 @@ Rust, C sees a small ABI, C++ is a header wrapper.
   =DifferentiableObjective= for a fused =(f, g)= function.
 - =xts_solver_create= / =xts_solver_step= / =xts_solver_free= ::
   Stateful C waist. Callbacks are per step. =abi_major= 1,
-  =abi_minor= 8, =layout_revision= 2. Compatibility checks major
+  =abi_minor= 9, =layout_revision= 2. Compatibility checks major
   and layout only.
 - =ManifoldKind= :: Embedded geometry. Euclidean is the identity.
   Sphere, SO(3), Stiefel ~St(n,1)~, and SE(3) implement

--- a/docs/orgmode/reference/sota.org
+++ b/docs/orgmode/reference/sota.org
@@ -201,8 +201,13 @@ rank-1 f64 vector.
   library that names Stiefel and SE(3) in the same waist
   ([[https://doi.org/10.1145/3218822][10.1145/3218822]]).
 
-Euclidean is the default. Sphere, SO(3) as a 9-vector, Stiefel
-~St(n,1)~, and SE(3) as a 12-vector are the tokens.
+Euclidean is the default. An isolated molecule uses
+~RigidQuotient~ (~R^{3N}/SE(3)~; Sella Cartesian
+~fix_translation~ / ~fix_rotation~,
+doi:10.1021/acs.jctc.2c00395) or ~MwRigid~ (Page–McIver
+mass-weighted Eckart, doi:10.1063/1.454172). Sphere, SO(3) as a
+9-vector, Stiefel ~St(n,1)~, and SE(3) as a 12-vector are
+matrix-manifold embeddings and reject a 3N cluster.
 
 ** Defaults in this crate
 

--- a/docs/orgmode/reference/sota.org
+++ b/docs/orgmode/reference/sota.org
@@ -128,8 +128,9 @@ Do not beat rematch (100/100 unless noted):
 | xtsci Fletcher–Reeves | 429282 (97 fail) | 44414 (69 fail) |
 | xtsci PSO | fail 100/100 | fail 100/100 |
 | sphere / Stiefel | fail 100/100 (maxiter) | maxiter ~11000 FC, 0 conv |
-| SO(3) | fail 100/100 (dim panic) | dim panic 9 vs 768 |
-| SE(3) | fail 100/100 (maxiter) | maxiter ~8000--9000 FC, 0 conv |
+| SO(3) | reject ~n!=9~ | not a 3N packing |
+| SE(3) | reject ~n!=12~ | not a 3N packing |
+| rigid_quotient / mw_rigid | Sella / IRC | ~R^{3N}/SE(3)~; Elja clocks not yet run |
 
 Dogleg is the only token that beats rematch, and only on LJ38.
 HiGHS on rematch is 153 on LJ38: better than OPTIM, worse than
@@ -140,8 +141,8 @@ tokens do not converge on these cluster / bulk geometries.
 
 | method | Borda | Class | Evidence |
 |---+---|---|---|
-| SO(3) | 11/12 crash bug | ~pack~ returns length 9 | ~so3.rs:23-34,109-121~; eindir ~bounds.rs:73~ is correct |
-| SE(3) | 10/12 contract | silent 9-prefix on any ~n>=12~ | ~se3.rs:12-37~; must reject ~n!=12~ |
+| SO(3) | 11/12 crash bug | ~n!=9~ is ~Error::ManifoldDim~ | ~so3.rs~ ~required_dim~; ~pack~ is never called on 3N |
+| SE(3) | 10/12 contract | ~n!=12~ is ~Error::ManifoldDim~ | ~se3.rs~ exact-12; no 9-prefix |
 | sphere | 12/12 misuse | impl correct, ~S^{3N-1}~ | ~sphere.rs:22-39~; cluster not on the unit sphere |
 | Stiefel | 12/12 alias | ~St(n,1)~ = sphere | ~stiefel.rs:11-23~; ~stiefel_p~ is always 1 |
 | HiGHS | 9/12 wrong QP | ~step_hess~ solves dense Newton QP | ~session.rs:322-336~; Morse ~n=768~ times out |
@@ -149,8 +150,9 @@ tokens do not converge on these cluster / bulk geometries.
 | SR2 | 8/12 bad update | non-secant rank-1 | ~qn.rs:265-281~ ~B += δ(y+Bs)^T / (δ·s)~ |
 | model Hessians | 11/12 wrong chemistry | covalent ~B^T k B~ vs pair | pair is the rematch ~P~ |
 
-SO(3) is the only panic: retract/project must not shrink ~x~.
-Sphere/Stiefel/SE(3) keep length and die on maxiter. PSO force
+SO(3) and SE(3) reject a 3N cluster. Sphere/Stiefel on 3N stay
+on ~S^{3N-1}~ and die on maxiter. Isolated molecules use
+~rigid_quotient~ or ~mw_rigid~. PSO force
 counts match ~max_iterations~ (10000 LJ38 / 1000 Morse) times
 swarm work, not a 230x230 product. SR2 has a denom skip; the
 update still fails the secant condition.

--- a/docs/orgmode/reference/sota.org
+++ b/docs/orgmode/reference/sota.org
@@ -130,7 +130,7 @@ Do not beat rematch (100/100 unless noted):
 | sphere / Stiefel | fail 100/100 (maxiter) | maxiter ~11000 FC, 0 conv |
 | SO(3) | reject ~n!=9~ | not a 3N packing |
 | SE(3) | reject ~n!=12~ | not a 3N packing |
-| rigid_quotient / mw_rigid | Sella / IRC | LJ38 20/20 identical to rematch (avg 120); Morse PBC 20/20 term=1 |
+| rigid_quotient / mw_rigid | Sella / IRC | LJ38 20/20 identical to rematch (avg 120); Morse PBC T(3) 0/20 fail, 19/20 identical FC |
 
 Dogleg is the only token that beats rematch, and only on LJ38.
 HiGHS on rematch is 153 on LJ38: better than OPTIM, worse than

--- a/docs/orgmode/reference/sota.org
+++ b/docs/orgmode/reference/sota.org
@@ -130,7 +130,7 @@ Do not beat rematch (100/100 unless noted):
 | sphere / Stiefel | fail 100/100 (maxiter) | maxiter ~11000 FC, 0 conv |
 | SO(3) | reject ~n!=9~ | not a 3N packing |
 | SE(3) | reject ~n!=12~ | not a 3N packing |
-| rigid_quotient / mw_rigid | Sella / IRC | ~R^{3N}/SE(3)~; Elja clocks not yet run |
+| rigid_quotient / mw_rigid | Sella / IRC | LJ38 20/20 identical to rematch (avg 120); Morse PBC 20/20 term=1 |
 
 Dogleg is the only token that beats rematch, and only on LJ38.
 HiGHS on rematch is 153 on LJ38: better than OPTIM, worse than

--- a/docs/orgmode/tutorials/quickstart.org
+++ b/docs/orgmode/tutorials/quickstart.org
@@ -65,8 +65,10 @@ let mut solver = Solver::new(Method::lbfgs(), Control::default(), 2);
 let rep = solver.step(&obj, &mut x).unwrap();
 #+end_src
 
-~set_manifold~ retracts that step onto a sphere, SO(3), Stiefel,
-or SE(3). Euclidean is the default.
+~set_manifold~ retracts that step. Isolated molecules use
+~RigidQuotient~ (~R^{3N}/SE(3)~) or ~MwRigid~ (mass-weighted
+Eckart). Sphere, SO(3), Stiefel, and SE(3) are matrix-manifold
+embeddings. Euclidean is the default.
 
 ** What just happened
 

--- a/docs/source/mainpage.dox
+++ b/docs/source/mainpage.dox
@@ -7,8 +7,10 @@
  * - \c xts_solver_t is the stateful waist (\c create / \c step / \c free).
  * - \c xts_minimize is the one-shot entry. Tensors are dlpk
  *   `DLManagedTensorVersioned`.
- * - \c xts_solver_set_manifold retracts onto Sphere, SO(3), Stiefel,
- *   or SE(3). Euclidean is the default.
+ * - \c xts_solver_set_manifold retracts onto RigidQuotient
+ *   (Sella Cartesian R^{3N}/SE(3)), MwRigid (Page-McIver Eckart),
+ *   Sphere, SO(3) (length 9), Stiefel St(n,1), or SE(3) (length 12).
+ *   Euclidean is the default.
  * - \c include/xts/optimize.hpp wraps that entry for C++.
  * - \c include/xts/xtensor.hpp adapts `xt::xarray`.
  *

--- a/include/xts.h
+++ b/include/xts.h
@@ -46,7 +46,7 @@ typedef struct xts_abi_stamp_t {
 } xts_abi_stamp_t;
 
 #define XTS_ABI_VERSION_MAJOR 1
-#define XTS_ABI_VERSION_MINOR 9
+#define XTS_ABI_VERSION_MINOR 10
 #define XTS_ABI_LAYOUT_REVISION 2
 
 /** Solver selector. \c XTS_LBFGS is the production unconstrained method. */
@@ -204,6 +204,8 @@ void xts_solver_set_manifold(xts_solver_t *solver, xts_manifold_t manifold);
  *  restores unit mass. */
 void xts_solver_set_masses(xts_solver_t *solver, const double *masses,
                            size_t n_atoms);
+/** Periodic cell. Nonzero drops rotation (Sella proj_rot): R^{3N}/T(3). */
+void xts_solver_set_periodic(xts_solver_t *solver, int32_t enabled);
 /**
  * One outer iteration: direction, line search, curvature update.
  * \a eval and \a grad are valid for this call only. \a x is in/out.

--- a/include/xts.h
+++ b/include/xts.h
@@ -46,7 +46,7 @@ typedef struct xts_abi_stamp_t {
 } xts_abi_stamp_t;
 
 #define XTS_ABI_VERSION_MAJOR 1
-#define XTS_ABI_VERSION_MINOR 8
+#define XTS_ABI_VERSION_MINOR 9
 #define XTS_ABI_LAYOUT_REVISION 2
 
 /** Solver selector. \c XTS_LBFGS is the production unconstrained method. */
@@ -186,15 +186,24 @@ void xts_solver_set_cautious(xts_solver_t *solver, double eps, double alpha);
 /** HiGHS feasible-set step. Nonzero enables it. Returns 0, or 1 if this
  *  build has no highs feature. */
 int32_t xts_solver_set_highs(xts_solver_t *solver, int32_t enabled);
-/** Embedded manifold. Euclidean is the default. */
+/** Embedded manifold. Euclidean is the default.
+ *  Molecular clusters use RIGID_QUOTIENT (Sella Cartesian T+R,
+ *  R^{3N}/SE(3)) or MW_RIGID (Page-McIver / Sella IRC Eckart).
+ *  SO3 is length 9; SE3 is length 12. */
 typedef enum xts_manifold_t {
     XTS_MANIFOLD_EUCLIDEAN = 0,
     XTS_MANIFOLD_SPHERE = 1,
     XTS_MANIFOLD_SO3 = 2,
     XTS_MANIFOLD_STIEFEL = 3,
-    XTS_MANIFOLD_SE3 = 4
+    XTS_MANIFOLD_SE3 = 4,
+    XTS_MANIFOLD_RIGID_QUOTIENT = 5,
+    XTS_MANIFOLD_MW_RIGID = 6
 } xts_manifold_t;
 void xts_solver_set_manifold(xts_solver_t *solver, xts_manifold_t manifold);
+/** Per-atom masses for MW_RIGID. n_atoms == 0 or masses == NULL
+ *  restores unit mass. */
+void xts_solver_set_masses(xts_solver_t *solver, const double *masses,
+                           size_t n_atoms);
 /**
  * One outer iteration: direction, line search, curvature update.
  * \a eval and \a grad are valid for this call only. \a x is in/out.

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,14 @@ pub enum Error {
     /// Newton / RFO / dogleg needs a Hessian oracle.
     #[error("Newton/RFO/dogleg needs a Hessian; call step_hess")]
     NeedHessian,
+    /// Packed manifold rejected this ambient dimension.
+    #[error("{kind} rejected dimension {got}")]
+    ManifoldDim {
+        /// Token (`so3`, `se3`, `rigid_quotient`, `mw_rigid`).
+        kind: &'static str,
+        /// Length of the working vector.
+        got: usize,
+    },
 }
 
 /// Result alias for this crate.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -49,7 +49,7 @@ pub struct xts_abi_stamp_t {
 }
 
 pub const XTS_ABI_VERSION_MAJOR: u16 = 1;
-pub const XTS_ABI_VERSION_MINOR: u16 = 9;
+pub const XTS_ABI_VERSION_MINOR: u16 = 10;
 pub const XTS_ABI_LAYOUT_REVISION: u16 = 2;
 
 /// Method tag. Keep this a closed C enum; Rust [`Method`] is the source.
@@ -987,6 +987,15 @@ pub unsafe extern "C" fn xts_solver_set_masses(
     }
     let slice = unsafe { slice::from_raw_parts(masses, n_atoms) };
     unsafe { (*solver).solver.set_masses(Array1::from(slice.to_vec())) };
+}
+
+/// Periodic cell. Nonzero: Sella `proj_rot = false`, quotient is \(R^{3N}/T(3)\).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xts_solver_set_periodic(solver: *mut xts_solver_t, enabled: i32) {
+    if solver.is_null() {
+        return;
+    }
+    unsafe { (*solver).solver.set_periodic(enabled != 0) };
 }
 
 /// One outer iteration. `x` is in/out. Callbacks live for this call only.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -18,8 +18,8 @@ use eindir_core::ffi::{
 use ndarray::{Array1, Array2};
 
 use crate::{
-    Accept, Control, HessianOracle, LineSearch, ManifoldKind, Method, NewtonKind, Oracle, QnStep,
-    Solver, minimize_method, minimize_method_hess,
+    minimize_method, minimize_method_hess, Accept, Control, HessianOracle, LineSearch,
+    ManifoldKind, Method, NewtonKind, Oracle, QnStep, Solver,
 };
 
 /// Status codes. 0 is success, matching metatensor / eindir.
@@ -49,7 +49,7 @@ pub struct xts_abi_stamp_t {
 }
 
 pub const XTS_ABI_VERSION_MAJOR: u16 = 1;
-pub const XTS_ABI_VERSION_MINOR: u16 = 8;
+pub const XTS_ABI_VERSION_MINOR: u16 = 9;
 pub const XTS_ABI_LAYOUT_REVISION: u16 = 2;
 
 /// Method tag. Keep this a closed C enum; Rust [`Method`] is the source.
@@ -935,8 +935,7 @@ pub unsafe extern "C" fn xts_solver_set_highs(solver: *mut xts_solver_t, enabled
     }
 }
 
-/// Embedded manifold. Tokens other than Euclidean are filled on
-/// `feat/manifold-*` branches.
+/// Embedded manifold.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum xts_manifold_t {
@@ -945,6 +944,10 @@ pub enum xts_manifold_t {
     XTS_MANIFOLD_SO3 = 2,
     XTS_MANIFOLD_STIEFEL = 3,
     XTS_MANIFOLD_SE3 = 4,
+    /// Sella Cartesian \(R^{3N}/\mathrm{SE}(3)\). 3N, N >= 2.
+    XTS_MANIFOLD_RIGID_QUOTIENT = 5,
+    /// Mass-weighted Eckart (Sella IRC / Page–McIver). 3N, N >= 2.
+    XTS_MANIFOLD_MW_RIGID = 6,
 }
 
 #[unsafe(no_mangle)]
@@ -960,9 +963,30 @@ pub unsafe extern "C" fn xts_solver_set_manifold(
         xts_manifold_t::XTS_MANIFOLD_SO3 => ManifoldKind::So3,
         xts_manifold_t::XTS_MANIFOLD_STIEFEL => ManifoldKind::Stiefel,
         xts_manifold_t::XTS_MANIFOLD_SE3 => ManifoldKind::Se3,
+        xts_manifold_t::XTS_MANIFOLD_RIGID_QUOTIENT => ManifoldKind::RigidQuotient,
+        xts_manifold_t::XTS_MANIFOLD_MW_RIGID => ManifoldKind::MwRigid,
         xts_manifold_t::XTS_MANIFOLD_EUCLIDEAN => ManifoldKind::Euclidean,
     };
     unsafe { (*solver).solver.set_manifold(kind) };
+}
+
+/// Per-atom masses for `XTS_MANIFOLD_MW_RIGID`. `n_atoms == 0` or a
+/// null pointer clears them (unit mass).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xts_solver_set_masses(
+    solver: *mut xts_solver_t,
+    masses: *const f64,
+    n_atoms: usize,
+) {
+    if solver.is_null() {
+        return;
+    }
+    if masses.is_null() || n_atoms == 0 {
+        unsafe { (*solver).solver.set_masses(Array1::zeros(0)) };
+        return;
+    }
+    let slice = unsafe { slice::from_raw_parts(masses, n_atoms) };
+    unsafe { (*solver).solver.set_masses(Array1::from(slice.to_vec())) };
 }
 
 /// One outer iteration. `x` is in/out. Callbacks live for this call only.

--- a/src/lbfgs.rs
+++ b/src/lbfgs.rs
@@ -203,6 +203,12 @@ impl Lbfgs {
         self.push_pair(s, y, None);
     }
 
+    /// Drop the newest pair, then push. Used after a manifold retract.
+    pub(crate) fn replace_newest(&mut self, s: Array1<f64>, y: Array1<f64>, gnorm: Option<f64>) {
+        let _ = self.memory.pop();
+        self.push_pair(s, y, gnorm);
+    }
+
     pub(crate) fn push_pair(&mut self, s: Array1<f64>, y: Array1<f64>, gnorm: Option<f64>) {
         let sy = s.dot(&y);
         let sn = s.iter().map(|v| v * v).sum::<f64>().sqrt();

--- a/src/manifold/mod.rs
+++ b/src/manifold/mod.rs
@@ -5,16 +5,26 @@
 //! Boumal, *An Introduction to Optimization on Smooth Manifolds*,
 //! <https://doi.org/10.1017/9781009166164>.
 //! manopt_cpp: `proj`, `retr`, `transp` on an embedded Euclidean vector.
+//!
+//! Isolated molecules and clusters use [`ManifoldKind::RigidQuotient`]
+//! (Sella Cartesian `fix_translation` / `fix_rotation`,
+//! \(R^{3N}/\mathrm{SE}(3)\)) or [`ManifoldKind::MwRigid`] (Page–McIver
+//! mass-weighted Eckart, the IRC metric). Sphere / SO(3)-9 / SE(3)-12
+//! are matrix-manifold embeddings, not a 3N cluster.
 
 use ndarray::Array1;
 
 mod euclidean;
+mod mw_rigid;
+mod rigid_quotient;
 mod se3;
 mod so3;
 mod sphere;
 mod stiefel;
 
 pub use euclidean::Euclidean;
+pub use mw_rigid::MwRigid;
+pub use rigid_quotient::RigidQuotient;
 pub use se3::Se3;
 pub use so3::So3;
 pub use sphere::Sphere;
@@ -30,10 +40,16 @@ pub enum ManifoldKind {
     Sphere,
     /// Rotation matrices SO(3), 9-vector row-major.
     So3,
-    /// Stiefel \(\mathrm{St}(n,p)\). `p` from [`ManifoldKind::stiefel_p`].
+    /// Stiefel \(\mathrm{St}(n,1)\). A single orthonormal column.
     Stiefel,
     /// Rigid motions SE(3): 3x3 row-major then translation (12).
     Se3,
+    /// Isolated-molecule shape space \(R^{3N}/\mathrm{SE}(3)\).
+    /// Sella Cartesian + `fix_translation` + `fix_rotation`.
+    RigidQuotient,
+    /// Mass-weighted Eckart: Sella IRC / Page–McIver metric on
+    /// the same quotient. Masses from [`crate::Solver::set_masses`].
+    MwRigid,
 }
 
 impl ManifoldKind {
@@ -41,19 +57,49 @@ impl ManifoldKind {
     pub fn stiefel_p(self) -> usize {
         1
     }
+
+    /// C ABI / INI token.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Euclidean => "euclidean",
+            Self::Sphere => "sphere",
+            Self::So3 => "so3",
+            Self::Stiefel => "stiefel",
+            Self::Se3 => "se3",
+            Self::RigidQuotient => "rigid_quotient",
+            Self::MwRigid => "mw_rigid",
+        }
+    }
 }
 
 /// manopt_cpp `AbstractManifold` on a rank-1 f64 vector.
 pub trait Manifold {
-    /// Tangent projection of an ambient vector at `x`.
+    /// `Ok` if `n` is a legal packing for this geometry.
+    fn required_dim(&self, n: usize) -> Result<(), usize> {
+        let _ = n;
+        Ok(())
+    }
+    /// Tangent projection of an ambient vector at `x`. Same length as `v`.
     fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64>;
-    /// Retraction of the tangent step `v` at `x`.
+    /// Retraction of the tangent step `v` at `x`. Same length as `x`.
     fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64>;
     /// Vector transport of `v` from `x_from` to `x_to`.
     fn transport(&self, x_from: &Array1<f64>, x_to: &Array1<f64>, v: &Array1<f64>) -> Array1<f64>;
 }
 
 impl Manifold for ManifoldKind {
+    fn required_dim(&self, n: usize) -> Result<(), usize> {
+        match self {
+            Self::Euclidean => Euclidean.required_dim(n),
+            Self::Sphere => Sphere.required_dim(n),
+            Self::So3 => So3.required_dim(n),
+            Self::Stiefel => Stiefel.required_dim(n),
+            Self::Se3 => Se3.required_dim(n),
+            Self::RigidQuotient => RigidQuotient.required_dim(n),
+            Self::MwRigid => MwRigid.required_dim(n),
+        }
+    }
+
     fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
         match self {
             Self::Euclidean => Euclidean.project(x, v),
@@ -61,6 +107,8 @@ impl Manifold for ManifoldKind {
             Self::So3 => So3.project(x, v),
             Self::Stiefel => Stiefel.project(x, v),
             Self::Se3 => Se3.project(x, v),
+            Self::RigidQuotient => RigidQuotient.project(x, v),
+            Self::MwRigid => MwRigid.project(x, v),
         }
     }
 
@@ -71,6 +119,8 @@ impl Manifold for ManifoldKind {
             Self::So3 => So3.retract(x, v),
             Self::Stiefel => Stiefel.retract(x, v),
             Self::Se3 => Se3.retract(x, v),
+            Self::RigidQuotient => RigidQuotient.retract(x, v),
+            Self::MwRigid => MwRigid.retract(x, v),
         }
     }
 
@@ -81,6 +131,8 @@ impl Manifold for ManifoldKind {
             Self::So3 => So3.transport(x_from, x_to, v),
             Self::Stiefel => Stiefel.transport(x_from, x_to, v),
             Self::Se3 => Se3.transport(x_from, x_to, v),
+            Self::RigidQuotient => RigidQuotient.transport(x_from, x_to, v),
+            Self::MwRigid => MwRigid.transport(x_from, x_to, v),
         }
     }
 }

--- a/src/manifold/mw_rigid.rs
+++ b/src/manifold/mw_rigid.rs
@@ -1,0 +1,45 @@
+//! Mass-weighted \(R^{3N}/\mathrm{SE}(3)\) (Eckart / Page–McIver).
+//!
+//! Sella IRC and gpr_optim `IRCDriver` work in mass-weighted Cartesians
+//! (`x_mw = sqrt(m) x`; Page and McIver, J. Chem. Phys. 88, 922 (1988),
+//! doi:10.1063/1.454172; Ishida, Morokuma, Komornicki 1977,
+//! doi:10.1063/1.434152). The tangent is the mass-weighted kernel of
+//! translations and infinitesimal rotations.
+//!
+//! Per-atom masses live on the session (`Solver::set_masses`). This
+//! type uses unit mass so it matches [`super::RigidQuotient`] until
+//! the session applies the metric.
+
+use ndarray::Array1;
+
+use crate::rigid::project_out_rot_trans;
+
+use super::Manifold;
+
+/// Eckart frame. Unit mass here; the session supplies real masses.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MwRigid;
+
+impl Manifold for MwRigid {
+    fn required_dim(&self, n: usize) -> Result<(), usize> {
+        if n >= 6 && n % 3 == 0 {
+            Ok(())
+        } else {
+            Err(n)
+        }
+    }
+
+    fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        let mut w = v.clone();
+        project_out_rot_trans(&mut w, x.view());
+        w
+    }
+
+    fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        x + v
+    }
+
+    fn transport(&self, _x_from: &Array1<f64>, x_to: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        self.project(x_to, v)
+    }
+}

--- a/src/manifold/rigid_quotient.rs
+++ b/src/manifold/rigid_quotient.rs
@@ -1,0 +1,67 @@
+//! Isolated-molecule shape space \(R^{3N}/\mathrm{SE}(3)\).
+//!
+//! Sella Cartesian PES: `fix_translation` plus `fix_rotation` on the
+//! whole cluster (Hermes, Sarsfield, Zádor, JCTC 2022,
+//! doi:10.1021/acs.jctc.2c00395). The tangent is the horizontal space
+//! of eOn `projectOutRotTrans`. The retraction is the horizontal lift
+//! `x + v`; energy is SE(3)-invariant so a rigid increment is a no-op.
+//!
+//! This is the molecular manifold for OptBench cluster minimization.
+//! \(S^{3N-1}\) and a lone SO(3) 9-vector are a different geometry.
+
+use ndarray::Array1;
+
+use crate::rigid::project_out_rot_trans;
+
+use super::Manifold;
+
+/// Horizontal lift of \(R^{3N}/\mathrm{SE}(3)\). Unit-mass Eckart.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RigidQuotient;
+
+impl Manifold for RigidQuotient {
+    fn required_dim(&self, n: usize) -> Result<(), usize> {
+        if n >= 6 && n % 3 == 0 {
+            Ok(())
+        } else {
+            Err(n)
+        }
+    }
+
+    fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        let mut w = v.clone();
+        project_out_rot_trans(&mut w, x.view());
+        w
+    }
+
+    fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        x + v
+    }
+
+    fn transport(&self, _x_from: &Array1<f64>, x_to: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        self.project(x_to, v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn translation_is_vertical() {
+        let x = array![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let v = array![0.3, 0.0, 0.0, 0.3, 0.0, 0.0, 0.3, 0.0, 0.0];
+        let t = RigidQuotient.project(&x, &v);
+        let n = t.iter().map(|a| a * a).sum::<f64>().sqrt();
+        assert!(n < 1e-12, "{t:?}");
+    }
+
+    #[test]
+    fn keeps_length() {
+        let x = Array1::from_elem(114, 0.1);
+        let v = Array1::from_elem(114, 0.01);
+        let y = RigidQuotient.retract(&x, &v);
+        assert_eq!(y.len(), 114);
+    }
+}

--- a/src/manifold/se3.rs
+++ b/src/manifold/se3.rs
@@ -1,4 +1,7 @@
 //! SE(3): row-major SO(3) (9) then translation (3). Length 12.
+//!
+//! Dimension is exactly 12. A 3N cluster is
+//! [`super::RigidQuotient`], not a 12-vector prefix.
 
 use ndarray::Array1;
 
@@ -9,8 +12,16 @@ use super::{so3::So3, Manifold};
 pub struct Se3;
 
 impl Manifold for Se3 {
+    fn required_dim(&self, n: usize) -> Result<(), usize> {
+        if n == 12 {
+            Ok(())
+        } else {
+            Err(12)
+        }
+    }
+
     fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
-        if x.len() < 12 || v.len() < 12 {
+        if x.len() != 12 || v.len() != 12 {
             return v.clone();
         }
         let xr = x.slice(ndarray::s![0..9]).to_owned();
@@ -24,7 +35,7 @@ impl Manifold for Se3 {
     }
 
     fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
-        if x.len() < 12 || v.len() < 12 {
+        if x.len() != 12 || v.len() != 12 {
             return x + v;
         }
         let xr = x.slice(ndarray::s![0..9]).to_owned();
@@ -100,5 +111,18 @@ mod tests {
             }
         }
         assert!((y[9] - 1.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn wrong_dim_is_identity_and_keeps_length() {
+        let x = Array1::from_elem(114, 0.1);
+        let v = Array1::from_elem(114, 0.01);
+        let y = Se3.retract(&x, &v);
+        assert_eq!(y.len(), 114);
+        for i in 0..114 {
+            assert!((y[i] - (x[i] + v[i])).abs() < 1e-15);
+        }
+        assert!(Se3.required_dim(114).is_err());
+        assert!(Se3.required_dim(12).is_ok());
     }
 }

--- a/src/manifold/so3.rs
+++ b/src/manifold/so3.rs
@@ -1,4 +1,7 @@
 //! SO(3) as a 9-vector, row-major. manopt_cpp `Rotation<3,1>`.
+//!
+//! Dimension is exactly 9. A 3N cluster is
+//! [`super::RigidQuotient`], not this embedding.
 
 use ndarray::Array1;
 
@@ -95,8 +98,16 @@ fn qr_pos(a: [[f64; 3]; 3]) -> [[f64; 3]; 3] {
 }
 
 impl Manifold for So3 {
+    fn required_dim(&self, n: usize) -> Result<(), usize> {
+        if n == 9 {
+            Ok(())
+        } else {
+            Err(9)
+        }
+    }
+
     fn project(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
-        if x.len() < 9 || v.len() < 9 {
+        if x.len() != 9 || v.len() != 9 {
             return v.clone();
         }
         let r = unpack(x);
@@ -107,7 +118,7 @@ impl Manifold for So3 {
     }
 
     fn retract(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
-        if x.len() < 9 || v.len() < 9 {
+        if x.len() != 9 || v.len() != 9 {
             return x + v;
         }
         let r = unpack(x);
@@ -144,5 +155,16 @@ mod tests {
                 assert!((rtr[i][j] - want).abs() < 1e-12, "{rtr:?}");
             }
         }
+    }
+
+    #[test]
+    fn wrong_dim_does_not_shrink() {
+        let x = Array1::from_elem(114, 0.1);
+        let v = Array1::from_elem(114, 0.01);
+        let y = So3.retract(&x, &v);
+        assert_eq!(y.len(), 114);
+        assert_eq!(So3.project(&x, &v).len(), 114);
+        assert!(So3.required_dim(114).is_err());
+        assert!(So3.required_dim(9).is_ok());
     }
 }

--- a/src/manifold/stiefel.rs
+++ b/src/manifold/stiefel.rs
@@ -1,4 +1,7 @@
 //! Stiefel \(\mathrm{St}(n,1)\): a single orthonormal column is the sphere.
+//!
+//! `p > 1` is not a length-\(n\) token. A 3N cluster is
+//! [`super::RigidQuotient`], not \(\mathrm{St}(3N, 1)\).
 
 use ndarray::Array1;
 

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -1,24 +1,56 @@
-//! Project translation and infinitesimal rotation out of a 3N vector.
+//! Horizontal space of \(R^{3N}/\mathrm{SE}(3)\).
+//!
+//! Sella Cartesian PES (`fix_translation` + `fix_rotation`; Hermes,
+//! Sarsfield, Zádor, JCTC 2022, doi:10.1021/acs.jctc.2c00395). Masses
+//! turn the inner product into the Page–McIver / Eckart metric used
+//! by Sella IRC and gpr_optim `IRCDriver` (Page and McIver 1988,
+//! doi:10.1063/1.454172).
 
 use ndarray::{Array1, ArrayView1};
 
-/// eOn `projectOutRotTrans`. No-op unless `x` is 3N with N >= 2.
+/// eOn `projectOutRotTrans`. Unit-mass Eckart. No-op unless `x` is 3N, N >= 2.
 pub(crate) fn project_out_rot_trans(vec: &mut Array1<f64>, pos: ArrayView1<f64>) {
+    project_out_rot_trans_mass(vec, pos, None);
+}
+
+/// Eckart conditions with optional per-atom masses (length N).
+///
+/// `sum_i m_i v_i = 0` and `sum_i m_i r_i × v_i = 0`. Missing or
+/// wrong-length masses fall back to unit mass.
+pub(crate) fn project_out_rot_trans_mass(
+    vec: &mut Array1<f64>,
+    pos: ArrayView1<f64>,
+    masses: Option<&[f64]>,
+) {
     let n = pos.len();
     if n < 6 || n % 3 != 0 || vec.len() != n {
         return;
     }
     let nat = n / 3;
+    let mass_ok = masses.map(|m| m.len() == nat).unwrap_or(false);
+    let m_at = |i: usize| -> f64 {
+        if mass_ok {
+            masses.unwrap()[i].max(0.0)
+        } else {
+            1.0
+        }
+    };
+
     let mut com = [0.0; 3];
+    let mut mtot = 0.0;
     for i in 0..nat {
-        com[0] += pos[3 * i];
-        com[1] += pos[3 * i + 1];
-        com[2] += pos[3 * i + 2];
+        let mi = m_at(i);
+        mtot += mi;
+        com[0] += mi * pos[3 * i];
+        com[1] += mi * pos[3 * i + 1];
+        com[2] += mi * pos[3 * i + 2];
     }
-    let inv = 1.0 / nat as f64;
-    com[0] *= inv;
-    com[1] *= inv;
-    com[2] *= inv;
+    if mtot <= 0.0 {
+        return;
+    }
+    com[0] /= mtot;
+    com[1] /= mtot;
+    com[2] /= mtot;
 
     let mut basis = Vec::with_capacity(6);
     for d in 0..3 {
@@ -50,19 +82,39 @@ pub(crate) fn project_out_rot_trans(vec: &mut Array1<f64>, pos: ArrayView1<f64>)
     for v in basis {
         let mut u = v;
         for e in &ortho {
-            let d = u.dot(e);
-            u.scaled_add(-d, e);
+            let d = mass_dot(&u, e, nat, &m_at);
+            // Subtract in the Euclidean chart; the coefficient used the
+            // mass inner product so the result is M-orthogonal to e.
+            let ee = mass_dot(e, e, nat, &m_at);
+            if ee > 1.0e-18 {
+                u.scaled_add(-d / ee, e);
+            }
         }
-        let nrm = l2(&u);
-        if nrm > 1.0e-9 {
-            u /= nrm;
+        let nrm2 = mass_dot(&u, &u, nat, &m_at);
+        if nrm2 > 1.0e-18 {
+            u /= nrm2.sqrt();
             ortho.push(u);
         }
     }
     for e in &ortho {
-        let d = vec.dot(e);
-        vec.scaled_add(-d, e);
+        let d = mass_dot(vec, e, nat, &m_at);
+        let ee = mass_dot(e, e, nat, &m_at);
+        if ee > 1.0e-18 {
+            vec.scaled_add(-d / ee, e);
+        }
     }
+}
+
+fn mass_dot<F>(a: &Array1<f64>, b: &Array1<f64>, nat: usize, m_at: &F) -> f64
+where
+    F: Fn(usize) -> f64,
+{
+    let mut s = 0.0;
+    for i in 0..nat {
+        let mi = m_at(i);
+        s += mi * (a[3 * i] * b[3 * i] + a[3 * i + 1] * b[3 * i + 1] + a[3 * i + 2] * b[3 * i + 2]);
+    }
+    s
 }
 
 fn l2(v: &Array1<f64>) -> f64 {
@@ -80,5 +132,24 @@ mod tests {
         let mut v = array![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
         project_out_rot_trans(&mut v, pos.view());
         assert!(l2(&v) < 1e-12);
+    }
+
+    #[test]
+    fn unequal_masses_still_kill_translation() {
+        let pos = array![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let mut v = array![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+        let masses = [16.0, 1.0, 1.0];
+        project_out_rot_trans_mass(&mut v, pos.view(), Some(&masses));
+        assert!(l2(&v) < 1e-12);
+    }
+
+    #[test]
+    fn unequal_masses_kill_mass_weighted_rotation() {
+        // Infinitesimal rotation about z of a planar triangle.
+        let pos = array![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0];
+        let mut v = array![0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0, 0.0];
+        let masses = [12.0, 1.0, 1.0];
+        project_out_rot_trans_mass(&mut v, pos.view(), Some(&masses));
+        assert!(l2(&v) < 1e-10, "{v:?}");
     }
 }

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -8,22 +8,26 @@
 
 use ndarray::{Array1, ArrayView1};
 
-/// eOn `projectOutRotTrans`. Unit-mass Eckart. No-op unless `x` is 3N, N >= 2.
+/// eOn `projectOutRotTrans`. Unit-mass Eckart. Isolated molecule (T+R).
 pub(crate) fn project_out_rot_trans(vec: &mut Array1<f64>, pos: ArrayView1<f64>) {
-    project_out_rot_trans_mass(vec, pos, None);
+    project_horizontal(vec, pos, None, true);
 }
 
-/// Eckart conditions with optional per-atom masses (length N).
+/// Horizontal space of \(R^{3N}/\mathrm{SE}(3)\) or \(R^{3N}/T(3)\).
 ///
-/// `sum_i m_i v_i = 0` and `sum_i m_i r_i × v_i = 0`. Missing or
-/// wrong-length masses fall back to unit mass.
-pub(crate) fn project_out_rot_trans_mass(
+/// `rotate` is Sella `proj_rot`: false under PBC (the cell kills
+/// rotational invariance). Masses are per atom (length N).
+pub(crate) fn project_horizontal(
     vec: &mut Array1<f64>,
     pos: ArrayView1<f64>,
     masses: Option<&[f64]>,
+    rotate: bool,
 ) {
     let n = pos.len();
-    if n < 6 || n % 3 != 0 || vec.len() != n {
+    if n < 3 || n % 3 != 0 || vec.len() != n {
+        return;
+    }
+    if rotate && n < 6 {
         return;
     }
     let nat = n / 3;
@@ -36,23 +40,7 @@ pub(crate) fn project_out_rot_trans_mass(
         }
     };
 
-    let mut com = [0.0; 3];
-    let mut mtot = 0.0;
-    for i in 0..nat {
-        let mi = m_at(i);
-        mtot += mi;
-        com[0] += mi * pos[3 * i];
-        com[1] += mi * pos[3 * i + 1];
-        com[2] += mi * pos[3 * i + 2];
-    }
-    if mtot <= 0.0 {
-        return;
-    }
-    com[0] /= mtot;
-    com[1] /= mtot;
-    com[2] /= mtot;
-
-    let mut basis = Vec::with_capacity(6);
+    let mut basis = Vec::with_capacity(if rotate { 6 } else { 3 });
     for d in 0..3 {
         let mut t = Array1::zeros(n);
         for j in 0..nat {
@@ -60,23 +48,39 @@ pub(crate) fn project_out_rot_trans_mass(
         }
         basis.push(t);
     }
-    let mut rx = Array1::zeros(n);
-    let mut ry = Array1::zeros(n);
-    let mut rz = Array1::zeros(n);
-    for i in 0..nat {
-        let x = pos[3 * i] - com[0];
-        let y = pos[3 * i + 1] - com[1];
-        let z = pos[3 * i + 2] - com[2];
-        rx[3 * i + 1] = -z;
-        rx[3 * i + 2] = y;
-        ry[3 * i] = z;
-        ry[3 * i + 2] = -x;
-        rz[3 * i] = -y;
-        rz[3 * i + 1] = x;
+    if rotate {
+        let mut com = [0.0; 3];
+        let mut mtot = 0.0;
+        for i in 0..nat {
+            let mi = m_at(i);
+            mtot += mi;
+            com[0] += mi * pos[3 * i];
+            com[1] += mi * pos[3 * i + 1];
+            com[2] += mi * pos[3 * i + 2];
+        }
+        if mtot > 0.0 {
+            com[0] /= mtot;
+            com[1] /= mtot;
+            com[2] /= mtot;
+        }
+        let mut rx = Array1::zeros(n);
+        let mut ry = Array1::zeros(n);
+        let mut rz = Array1::zeros(n);
+        for i in 0..nat {
+            let x = pos[3 * i] - com[0];
+            let y = pos[3 * i + 1] - com[1];
+            let z = pos[3 * i + 2] - com[2];
+            rx[3 * i + 1] = -z;
+            rx[3 * i + 2] = y;
+            ry[3 * i] = z;
+            ry[3 * i + 2] = -x;
+            rz[3 * i] = -y;
+            rz[3 * i + 1] = x;
+        }
+        basis.push(rx);
+        basis.push(ry);
+        basis.push(rz);
     }
-    basis.push(rx);
-    basis.push(ry);
-    basis.push(rz);
 
     let mut ortho: Vec<Array1<f64>> = Vec::with_capacity(6);
     for v in basis {
@@ -139,7 +143,7 @@ mod tests {
         let pos = array![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
         let mut v = array![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
         let masses = [16.0, 1.0, 1.0];
-        project_out_rot_trans_mass(&mut v, pos.view(), Some(&masses));
+        project_horizontal(&mut v, pos.view(), Some(&masses), true);
         assert!(l2(&v) < 1e-12);
     }
 
@@ -149,7 +153,19 @@ mod tests {
         let pos = array![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0];
         let mut v = array![0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0, 0.0];
         let masses = [12.0, 1.0, 1.0];
-        project_out_rot_trans_mass(&mut v, pos.view(), Some(&masses));
+        project_horizontal(&mut v, pos.view(), Some(&masses), true);
         assert!(l2(&v) < 1e-10, "{v:?}");
+    }
+
+    #[test]
+    fn periodic_keeps_rotation_drops_translation() {
+        let pos = array![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0];
+        let rot = array![0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0, 0.0];
+        let mut v = rot.clone();
+        project_horizontal(&mut v, pos.view(), None, false);
+        assert!(l2(&v) > 0.5, "rotation was removed under PBC {v:?}");
+        let mut t = array![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+        project_horizontal(&mut t, pos.view(), None, false);
+        assert!(l2(&t) < 1e-12, "translation survived under PBC {t:?}");
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,7 +23,7 @@ use crate::pso::{random_velocity, update_swarm, Particle, RNG_SEED};
 use crate::qn::{bfgs_inverse_update, solve_dense, sr1_inverse_update, sr2_hessian_update};
 use crate::qn_step::QnStep;
 use crate::report::Report;
-use crate::rigid::{project_out_rot_trans, project_out_rot_trans_mass};
+use crate::rigid::{project_horizontal, project_out_rot_trans};
 use crate::step::{l2, next_istep, scale_step, scale_step_atom, take_step};
 use crate::trust::{
     accept_ratio, dogleg_direction, predicted_reduction, reduction_ratio, update_radius,
@@ -41,6 +41,8 @@ pub struct Solver {
     e_hist: VecDeque<f64>,
     atom_maxmove: Option<f64>,
     project_rigid: bool,
+    /// Sella `proj_rot`: false under PBC. Rotation is not a symmetry of the cell.
+    periodic: bool,
     manifold: ManifoldKind,
     /// Per-atom masses for [`ManifoldKind::MwRigid`]. Length N, not 3N.
     masses: Option<Array1<f64>>,
@@ -124,6 +126,7 @@ impl Solver {
             e_hist: VecDeque::new(),
             atom_maxmove: None,
             project_rigid: false,
+            periodic: false,
             manifold: ManifoldKind::Euclidean,
             masses: None,
             #[cfg(feature = "highs")]
@@ -158,6 +161,11 @@ impl Solver {
     /// eOn `lbfgs_project_rigid`. Isolated clusters only.
     pub fn set_project_rigid(&mut self, enabled: bool) {
         self.project_rigid = enabled;
+    }
+
+    /// Periodic cell. Sella leaves `proj_rot` off; the quotient is \(R^{3N}/T(3)\).
+    pub fn set_periodic(&mut self, periodic: bool) {
+        self.periodic = periodic;
     }
 
     /// Embedded manifold for project / retract / transport.
@@ -230,18 +238,18 @@ impl Solver {
         })
     }
 
-    /// Tangent projection. `MwRigid` uses session masses (Eckart).
+    /// Tangent projection. Periodic cells drop rotation (Sella `proj_rot`).
     fn project_vec(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
         match self.manifold {
             ManifoldKind::MwRigid => {
                 let mut w = v.clone();
                 let masses = self.masses.as_ref().and_then(|m| m.as_slice());
-                project_out_rot_trans_mass(&mut w, x.view(), masses);
+                project_horizontal(&mut w, x.view(), masses, !self.periodic);
                 w
             }
             ManifoldKind::RigidQuotient => {
                 let mut w = v.clone();
-                project_out_rot_trans(&mut w, x.view());
+                project_horizontal(&mut w, x.view(), None, !self.periodic);
                 w
             }
             other => other.project(x, v),

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,26 +4,26 @@ use std::collections::VecDeque;
 
 use eindir_core::{DifferentiableObjective, Objective};
 use ndarray::{Array1, Array2};
-use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rand::SeedableRng;
 
-use crate::accept::{Accept, accept_step};
+use crate::accept::{accept_step, Accept};
 use crate::adam::adam_direction;
 use crate::bb::bb_direction;
 use crate::control::Control;
 use crate::error::{Error, Result};
-use crate::fire::{FireState, fire_after_v1, fire_displacement};
+use crate::fire::{fire_after_v1, fire_displacement, FireState};
 use crate::lbfgs::{GradNorm, Lbfgs};
 use crate::linesearch::LineSearch;
 use crate::manifold::{Manifold, ManifoldKind};
 use crate::method::Method;
-use crate::newton::{HessianObjective, NewtonKind, rfo_direction, shifted_newton};
+use crate::newton::{rfo_direction, shifted_newton, HessianObjective, NewtonKind};
 use crate::nlcg::{Conjugacy, ConjugacyContext, Restart};
-use crate::pso::{Particle, RNG_SEED, random_velocity, update_swarm};
+use crate::pso::{random_velocity, update_swarm, Particle, RNG_SEED};
 use crate::qn::{bfgs_inverse_update, solve_dense, sr1_inverse_update, sr2_hessian_update};
 use crate::qn_step::QnStep;
 use crate::report::Report;
-use crate::rigid::project_out_rot_trans;
+use crate::rigid::{project_out_rot_trans, project_out_rot_trans_mass};
 use crate::step::{l2, next_istep, scale_step, scale_step_atom, take_step};
 use crate::trust::{
     accept_ratio, dogleg_direction, predicted_reduction, reduction_ratio, update_radius,
@@ -42,6 +42,8 @@ pub struct Solver {
     atom_maxmove: Option<f64>,
     project_rigid: bool,
     manifold: ManifoldKind,
+    /// Per-atom masses for [`ManifoldKind::MwRigid`]. Length N, not 3N.
+    masses: Option<Array1<f64>>,
     #[cfg(feature = "highs")]
     highs: bool,
     last_pos: Option<Array1<f64>>,
@@ -123,6 +125,7 @@ impl Solver {
             atom_maxmove: None,
             project_rigid: false,
             manifold: ManifoldKind::Euclidean,
+            masses: None,
             #[cfg(feature = "highs")]
             highs: false,
             last_pos: None,
@@ -165,6 +168,16 @@ impl Solver {
         self.manifold = kind;
     }
 
+    /// Per-atom masses for [`ManifoldKind::MwRigid`] (Page–McIver / Eckart).
+    /// Empty clears them (unit mass).
+    pub fn set_masses(&mut self, masses: Array1<f64>) {
+        if masses.is_empty() {
+            self.masses = None;
+        } else {
+            self.masses = Some(masses);
+        }
+    }
+
     /// Al-Baali extra-updates on the newest L-BFGS pair.
     pub fn set_extra_updates(&mut self, extra: usize) {
         if let Inner::Lbfgs(solver) = &mut self.inner {
@@ -205,6 +218,47 @@ impl Solver {
                 };
             }
         }
+    }
+
+    fn check_manifold(&self, n: usize) -> Result<()> {
+        if self.manifold.required_dim(n).is_ok() {
+            return Ok(());
+        }
+        Err(Error::ManifoldDim {
+            kind: self.manifold.as_str(),
+            got: n,
+        })
+    }
+
+    /// Tangent projection. `MwRigid` uses session masses (Eckart).
+    fn project_vec(&self, x: &Array1<f64>, v: &Array1<f64>) -> Array1<f64> {
+        match self.manifold {
+            ManifoldKind::MwRigid => {
+                let mut w = v.clone();
+                let masses = self.masses.as_ref().and_then(|m| m.as_slice());
+                project_out_rot_trans_mass(&mut w, x.view(), masses);
+                w
+            }
+            ManifoldKind::RigidQuotient => {
+                let mut w = v.clone();
+                project_out_rot_trans(&mut w, x.view());
+                w
+            }
+            other => other.project(x, v),
+        }
+    }
+
+    fn horizontal_grad(&self, x: &Array1<f64>, grad: &Array1<f64>) -> Array1<f64> {
+        let mut g = self.project_vec(x, grad);
+        if self.project_rigid
+            && !matches!(
+                self.manifold,
+                ManifoldKind::RigidQuotient | ManifoldKind::MwRigid
+            )
+        {
+            project_out_rot_trans(&mut g, x.view());
+        }
+        g
     }
 
     fn same_last_x(&self, x: &Array1<f64>) -> bool {
@@ -284,6 +338,7 @@ impl Solver {
                 dim: self.dim,
             });
         }
+        self.check_manifold(x.len())?;
         let newton_kind = match &self.inner {
             Inner::Newton { kind } => Some(*kind),
             Inner::Lbfgs(_) => match self.qn_step {
@@ -303,9 +358,7 @@ impl Solver {
         } else {
             obj.value_and_gradient(x.view())
         };
-        if self.project_rigid {
-            project_out_rot_trans(&mut grad, x.view());
-        }
+        grad = self.horizontal_grad(x, &grad);
         let gnorm = l2(&grad);
         if gnorm < self.control.gtol {
             return Ok(Report {
@@ -381,7 +434,7 @@ impl Solver {
         if self.project_rigid {
             project_out_rot_trans(&mut dir, x.view());
         }
-        dir = self.manifold.project(x, &dir);
+        dir = self.project_vec(x, &dir);
         let old = x.clone();
         let gold = grad.clone();
         let (npos, nval, ngrad, moved) = accept_step(
@@ -401,11 +454,15 @@ impl Solver {
             value = nval;
             grad = ngrad;
         }
+        grad = self.horizontal_grad(x, &grad);
         self.remember(x, value, &grad);
-        if let Inner::Lbfgs(solver) = &mut self.inner {
-            if x.iter().zip(old.iter()).any(|(a, b)| a != b) {
-                solver.push_pair(&*x - &old, &grad - &gold, Some(l2(&grad)));
-            }
+        let pair = if x.iter().zip(old.iter()).any(|(a, b)| a != b) {
+            Some((self.project_vec(x, &(&*x - &old)), &grad - &gold, l2(&grad)))
+        } else {
+            None
+        };
+        if let (Inner::Lbfgs(solver), Some((s, y, gn))) = (&mut self.inner, pair) {
+            solver.push_pair(s, &y, Some(gn));
         }
         self.steps += 1;
         Ok(Report {
@@ -487,6 +544,7 @@ impl Solver {
                 dim: self.dim,
             });
         }
+        self.check_manifold(x.len())?;
         let cached = self.same_last_x(x);
         if !cached {
             *x = obj.bounds().clip(x.view());
@@ -501,6 +559,7 @@ impl Solver {
         } else {
             obj.value_and_gradient(x.view())
         };
+        grad = self.horizontal_grad(x, &grad);
         let gnorm = l2(&grad);
         if gnorm < self.control.gtol {
             return Ok(Report {
@@ -728,6 +787,7 @@ impl Solver {
             value = ev.0;
             grad = ev.1;
         }
+        grad = self.horizontal_grad(x, &grad);
 
         self.remember(x, value, &grad);
         self.steps += 1;

--- a/src/session.rs
+++ b/src/session.rs
@@ -261,6 +261,32 @@ impl Solver {
         g
     }
 
+    /// Vector transport. Quotient manifolds project at the arrival point.
+    fn transport_vec(
+        &self,
+        x_from: &Array1<f64>,
+        x_to: &Array1<f64>,
+        v: &Array1<f64>,
+    ) -> Array1<f64> {
+        match self.manifold {
+            ManifoldKind::RigidQuotient | ManifoldKind::MwRigid => self.project_vec(x_to, v),
+            other => other.transport(x_from, x_to, v),
+        }
+    }
+
+    /// Riemannian L-BFGS pair at `x`: `s = T(x - old)`, `y = g - T(g_old)`.
+    fn lbfgs_sy(
+        &self,
+        old: &Array1<f64>,
+        x: &Array1<f64>,
+        gold: &Array1<f64>,
+        grad: &Array1<f64>,
+    ) -> (Array1<f64>, Array1<f64>) {
+        let s = self.transport_vec(old, x, &(x - old));
+        let y = grad - &self.transport_vec(old, x, gold);
+        (s, y)
+    }
+
     fn same_last_x(&self, x: &Array1<f64>) -> bool {
         match &self.last_pos {
             Some(p) if p.len() == x.len() => p
@@ -406,11 +432,16 @@ impl Solver {
                     value = nval;
                     grad = ngrad;
                 }
+                grad = self.horizontal_grad(x, &grad);
                 self.remember(x, value, &grad);
-                if let Inner::Lbfgs(solver) = &mut self.inner {
-                    if x.iter().zip(old.iter()).any(|(a, b)| a != b) {
-                        solver.push_pair(&*x - &old, &grad - &gold, Some(l2(&grad)));
-                    }
+                let pair = if x.iter().zip(old.iter()).any(|(a, b)| a != b) {
+                    let (s, y) = self.lbfgs_sy(&old, x, &gold, &grad);
+                    Some((s, y, l2(&grad)))
+                } else {
+                    None
+                };
+                if let (Inner::Lbfgs(solver), Some((s, y, gn))) = (&mut self.inner, pair) {
+                    solver.push_pair(s, y, Some(gn));
                 }
                 self.steps += 1;
                 return Ok(Report {
@@ -457,7 +488,8 @@ impl Solver {
         grad = self.horizontal_grad(x, &grad);
         self.remember(x, value, &grad);
         let pair = if x.iter().zip(old.iter()).any(|(a, b)| a != b) {
-            Some((self.project_vec(x, &(&*x - &old)), &grad - &gold, l2(&grad)))
+            let (s, y) = self.lbfgs_sy(&old, x, &gold, &grad);
+            Some((s, y, l2(&grad)))
         } else {
             None
         };
@@ -571,6 +603,7 @@ impl Solver {
         }
 
         let start = x.clone();
+        let gold = grad.clone();
         match &mut self.inner {
             Inner::Lbfgs(solver) => {
                 solver.step_objective(
@@ -788,6 +821,18 @@ impl Solver {
             grad = ev.1;
         }
         grad = self.horizontal_grad(x, &grad);
+
+        let pair = if matches!(self.inner, Inner::Lbfgs(_))
+            && x.iter().zip(start.iter()).any(|(a, b)| a != b)
+        {
+            let (s, y) = self.lbfgs_sy(&start, x, &gold, &grad);
+            Some((s, y, l2(&grad)))
+        } else {
+            None
+        };
+        if let (Inner::Lbfgs(solver), Some((s, y, gn))) = (&mut self.inner, pair) {
+            solver.replace_newest(s, y, Some(gn));
+        }
 
         self.remember(x, value, &grad);
         self.steps += 1;

--- a/src/session.rs
+++ b/src/session.rs
@@ -462,7 +462,7 @@ impl Solver {
             None
         };
         if let (Inner::Lbfgs(solver), Some((s, y, gn))) = (&mut self.inner, pair) {
-            solver.push_pair(s, &y, Some(gn));
+            solver.push_pair(s, y, Some(gn));
         }
         self.steps += 1;
         Ok(Report {

--- a/tests/c_abi.rs
+++ b/tests/c_abi.rs
@@ -448,7 +448,7 @@ fn fused_evalgrad_is_one_callback_per_oracle() {
 fn abi_stamp_identifies_this_optimizer_layout() {
     let stamp = xts_abi_stamp();
     assert_eq!(stamp.abi_major, 1);
-    assert_eq!(stamp.abi_minor, 9);
+    assert_eq!(stamp.abi_minor, 10);
     assert_eq!(stamp.layout_revision, 2);
     assert_eq!(unsafe { xts_abi_compatible(&stamp) }, 1);
 }

--- a/tests/c_abi.rs
+++ b/tests/c_abi.rs
@@ -448,7 +448,7 @@ fn fused_evalgrad_is_one_callback_per_oracle() {
 fn abi_stamp_identifies_this_optimizer_layout() {
     let stamp = xts_abi_stamp();
     assert_eq!(stamp.abi_major, 1);
-    assert_eq!(stamp.abi_minor, 8);
+    assert_eq!(stamp.abi_minor, 9);
     assert_eq!(stamp.layout_revision, 2);
     assert_eq!(unsafe { xts_abi_compatible(&stamp) }, 1);
 }

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -352,6 +352,101 @@ fn default_manifold_is_euclidean() {
 }
 
 #[test]
+fn so3_rejects_a_3n_cluster() {
+    let obj = Rosenbrock::<6>::new();
+    let mut x = Array1::from_elem(6, 0.1);
+    let mut solver = Solver::new(Method::Steepest, control(), 6);
+    solver.set_manifold(xtsci_optimize::ManifoldKind::So3);
+    let err = solver.step(&obj, &mut x).unwrap_err();
+    match err {
+        xtsci_optimize::Error::ManifoldDim { kind, got } => {
+            assert_eq!(kind, "so3");
+            assert_eq!(got, 6);
+        }
+        other => panic!("expected ManifoldDim, got {other:?}"),
+    }
+}
+
+#[test]
+fn se3_rejects_a_3n_cluster() {
+    let obj = Rosenbrock::<114>::new();
+    let mut x = Array1::from_elem(114, 0.1);
+    let mut solver = Solver::new(Method::Steepest, control(), 114);
+    solver.set_manifold(xtsci_optimize::ManifoldKind::Se3);
+    let err = solver.step(&obj, &mut x).unwrap_err();
+    match err {
+        xtsci_optimize::Error::ManifoldDim { kind, got } => {
+            assert_eq!(kind, "se3");
+            assert_eq!(got, 114);
+        }
+        other => panic!("expected ManifoldDim, got {other:?}"),
+    }
+}
+
+#[test]
+fn rigid_quotient_drops_translation_and_keeps_3n() {
+    use eindir_core::{Bounds, DifferentiableObjective, Gradient, Objective};
+    use ndarray::ArrayView1;
+
+    struct Pair;
+    impl Objective<f64> for Pair {
+        fn dim(&self) -> usize {
+            9
+        }
+        fn bounds(&self) -> &Bounds<f64> {
+            use std::sync::OnceLock;
+            static B: OnceLock<Bounds<f64>> = OnceLock::new();
+            B.get_or_init(|| {
+                Bounds::new(Array1::from_elem(9, -4.0), Array1::from_elem(9, 4.0), 0.0)
+            })
+        }
+        fn eval(&self, x: ArrayView1<f64>) -> f64 {
+            let d01 = (x[0] - x[3]).powi(2) + (x[1] - x[4]).powi(2) + (x[2] - x[5]).powi(2);
+            let d02 = (x[0] - x[6]).powi(2) + (x[1] - x[7]).powi(2) + (x[2] - x[8]).powi(2);
+            0.5 * ((d01.sqrt() - 1.0).powi(2) + (d02.sqrt() - 1.0).powi(2))
+        }
+    }
+    impl Gradient<f64> for Pair {
+        fn dim(&self) -> usize {
+            9
+        }
+        fn grad(&self, x: ArrayView1<f64>) -> Array1<f64> {
+            let e = 1e-6;
+            let f0 = self.eval(x);
+            let mut g = Array1::zeros(9);
+            let mut y = x.to_owned();
+            for i in 0..9 {
+                y[i] += e;
+                g[i] = (self.eval(y.view()) - f0) / e;
+                y[i] = x[i];
+            }
+            g
+        }
+    }
+    impl DifferentiableObjective<f64> for Pair {
+        fn value_and_gradient(&self, x: ArrayView1<f64>) -> (f64, Array1<f64>) {
+            (self.eval(x), self.grad(x))
+        }
+    }
+
+    let obj = Pair;
+    let mut x = array![0.0, 0.0, 0.0, 1.2, 0.0, 0.0, 0.0, 1.2, 0.0];
+    let mut solver = Solver::new(Method::Steepest, control(), 9);
+    solver.set_manifold(xtsci_optimize::ManifoldKind::RigidQuotient);
+    let com0 = [(x[0] + x[3] + x[6]) / 3.0, (x[1] + x[4] + x[7]) / 3.0];
+    for _ in 0..20 {
+        let _ = solver.step(&obj, &mut x).unwrap();
+        assert_eq!(x.len(), 9);
+    }
+    let com1 = [(x[0] + x[3] + x[6]) / 3.0, (x[1] + x[4] + x[7]) / 3.0];
+    assert!(
+        (com1[0] - com0[0]).abs() < 1e-8,
+        "COM drifted {com0:?} -> {com1:?}"
+    );
+    assert!((com1[1] - com0[1]).abs() < 1e-8);
+}
+
+#[test]
 fn nlcg_second_step_is_not_steepest() {
     let obj = Rosenbrock::<2>::new();
     let mut a = array![-1.2, 1.0];


### PR DESCRIPTION
The molecular manifold is Sella Cartesian `fix_translation` + `fix_rotation` (`R^{3N}/SE(3)`, Hermes, Sarsfield, Zádor, JCTC 2022, doi:10.1021/acs.jctc.2c00395), not `S^{3N-1}` and not a packed SO(3) 9-vector.

- `rigid_quotient`: horizontal space of eOn `projectOutRotTrans`. Retract is the lift `x + v`.
- `mw_rigid`: the same quotient with the Page-McIver mass-weighted inner product (Sella IRC / gpr_optim `IRCDriver`, doi:10.1063/1.454172, doi:10.1063/1.434152). `xts_solver_set_masses` takes N atomic masses.
- `so3` rejects any length other than 9. `se3` rejects any length other than 12. Neither packs nor prefix-interprets a 3N cluster.
- Session `gtol` uses the projected gradient. L-BFGS `s` is transported into the tangent.

`abi_minor` 9. Sella TRICs (bonds / angles / dihedrals plus fragment T/R) are a different chart of the same physical manifold; they are not a separate packing here.